### PR TITLE
Bump isolate num_boxes to INT_MAX in entrypoint

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -113,5 +113,14 @@ else
     echo "[entrypoint] cgroup v2 setup unavailable; isolate stays in rlimit mode (memory limits enforced as virtual address)"
 fi
 
+# isolate v2 (ioi/isolate) ships num_boxes=1000 by default. IsolateJob uses
+# `submission.id % INT_MAX` as the box id, so any submission id >= 1000
+# fails with "Sandbox ID out of range". The legacy judge0/isolate fork that
+# the upstream compilers/Dockerfile used had this patched to INT_MAX; that
+# patch was lost when compilers/NewtonDockerfile-v2 switched to ioi/isolate.
+# TODO: move into compilers image (sed default.cf before `make install`) on
+# next compiler base bump and drop this line.
+sed -i 's/^num_boxes\s*=.*/num_boxes = 2147483647/' /usr/local/etc/isolate
+
 cron
 exec "$@"


### PR DESCRIPTION
## Summary

- Prod started rejecting every submission with `Sandbox ID out of range (allowed: 0-999)` after the AL2 → AL2023 NodeClass flip, which moved the code-compiler nodepool from cgroup-v1 (rlimit fallback) onto cgroup-v2 (so isolate `--cg --init` actually runs).
- Root cause: `IsolateJob` uses `submission.id % INT_MAX` as the isolate box id (`app/jobs/isolate_job.rb:63`), but `ioi/isolate` v2 ships with `num_boxes = 1000` in `default.cf`. The legacy `judge0/isolate` fork that the upstream `compilers/Dockerfile` used had this patched to INT_MAX; the patch was dropped when `compilers/NewtonDockerfile-v2` (0.26+) switched to upstream `ioi/isolate`. Staging didn't surface this because staging's max submission id is still <1000.
- Fix: `sed` `/usr/local/etc/isolate` at container start so the limit matches the IsolateJob modulus. Stopgap — the correct long-term home is the compilers image (patch `default.cf` before `make install`) on the next compiler base bump; left a TODO at the call site.

## Test plan

- [ ] Build `newton-judge0:0.67` from this branch (amd64 EC2)
- [ ] On a fresh prod-like cgroup-v2 host, `docker exec ... grep num_boxes /usr/local/etc/isolate` shows `2147483647`
- [ ] Smoke: `JUDGE0_URL=https://judge0-public.staging-newtonschool.co bin/newton-smoke-test` → 23/0/0 (regression check — staging shouldn't break)
- [ ] Roll one prod pod, submit a job whose submission id ≥ 1000, confirm no `Sandbox ID out of range` and the result returns Accepted/expected status
- [ ] Then full prod rollout

🤖 Generated with [Claude Code](https://claude.com/claude-code)