### PR TITLE
Bake OpenSSL CA bundle env into NewtonDockerfile

### DIFF
--- a/NewtonDockerfile
+++ b/NewtonDockerfile
@@ -74,6 +74,17 @@ RUN set -xe && \
 ENV PATH "/usr/local/ruby-${APP_RUBY_VERSION}/bin:/opt/.gem/bin:$PATH"
 ENV GEM_HOME "/opt/.gem/"
 
+# OpenSSL 1.1.1w above is built with --openssldir=/usr/local/openssl-1.1.1w
+# and `make install_sw`, which does NOT install a CA bundle — that
+# directory ends up with no cert.pem and an empty certs/. Ruby 2.7's
+# openssl extension is linked against this OpenSSL, so its compiled-in
+# DEFAULT_CERT_FILE / DEFAULT_CERT_DIR resolve to that empty prefix and
+# every outbound HTTPS call fails with "unable to get local issuer
+# certificate". Point Ruby at Bookworm's system bundle (installed by
+# the ca-certificates package in the compilers base image) instead.
+ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \
+    SSL_CERT_DIR=/etc/ssl/certs
+
 # Step 4: bundler + aglio (now Ruby is in PATH)
 RUN echo "gem: --no-document" > /root/.gemrc && \
     gem install bundler:2.1.4 && \


### PR DESCRIPTION
## Summary

- Add `SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt` and `SSL_CERT_DIR=/etc/ssl/certs` to `NewtonDockerfile` so Ruby's TLS layer finds the system trust store.
- Closes the long-standing gap where OpenSSL 1.1.1w in this image was built with `--openssldir=/usr/local/openssl-1.1.1w` + `make install_sw` → no CA bundle in that prefix → every outbound Ruby HTTPS call failed with `SSL_connect ... certificate verify failed (unable to get local issuer certificate)`.

## Context

Hit in prod **2026-05-03**: workers couldn't download HTTPS test cases from CloudFront. The same TLS failure on the callback path (`HTTParty.put` in `IsolateJob#call_callback`) was being silently swallowed by the empty `rescue Exception => e` blocks at `app/jobs/isolate_job.rb:378,381`, so the bug only surfaced via the test-case-download code path.

A k8s-level stopgap landed in `kubernetes-cluster-infra` first (same env vars on the four judge0 deployments) and confirmed the fix end-to-end before this PR. This change moves the fix into the image so:

1. `docker run newtonschool/newton-judge0:<tag>` outside the cluster works without depending on env injection.
2. Future deployments / new clusters don't need to remember to set these.

## Why not other fixes

- **`apt-get install ca-certificates`**: already installed by the compilers base image (`compilers/NewtonDockerFiles/NewtonDockerfile-v2:72`); the bundle is on disk, just not in Ruby's OpenSSL search path. No-op.
- **`make install_ssldirs`** during the OpenSSL build: would only install OpenSSL's tiny default cert directory layout, not the trusted Mozilla bundle.
- **Symlinks `/usr/local/openssl-1.1.1w/cert.pem` → `/etc/ssl/certs/ca-certificates.crt`**: also works and is more bulletproof against env scrubbing in spawned subprocesses, but env vars are the conventional Bookworm-Ruby fix and easier to override per-deployment if ever needed. Happy to switch if reviewers prefer.

## Test plan

- [x] Stopgap k8s env fix verified working in prod (test-case download succeeds, no more SSL errors).
- [ ] Build amd64 image with this change: `docker buildx build --platform linux/amd64 -f NewtonDockerfile -t newtonschool/newton-judge0:<next-tag> --load .`
- [ ] Inside container, confirm Ruby sees the bundle:
  ```bash
  ruby -ropenssl -e 'p ENV["SSL_CERT_FILE"], OpenSSL::X509::DEFAULT_CERT_FILE; p File.exist?(ENV["SSL_CERT_FILE"])'
  ruby -ropen-uri -e 'puts URI.open("https://www.google.com").status'
  ```
- [ ] `bin/newton-smoke-test` passes against a freshly built image (sanity).
- [ ] After image bumps to next tag, optionally drop the k8s env stopgap from `kubernetes-cluster-infra/clusters/newton-core/base/code-compiler/deployment.yaml` (left in place is also fine — it's idempotent).

## Follow-up (separate PR)

Replace the empty `rescue Exception => e` blocks in `IsolateJob#call_callback` with `Rails.logger.error(e.full_message)` so future TLS / network failures aren't silent. Wasn't bundled here to keep the diff minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)