### PR TITLE
0.67: Phase 3 — submission asset capture (Verilog wave.vcd first)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,8 +174,9 @@ JUDGE0_URL=http://localhost:2358 ./bin/newton-smoke-test
 
 Submits a hello-world for every active language id. Expected (post-0.67
 with Phase 3 asset capture; three Verilog cases — testbench-in-stdin,
-empty-stdin self-contained, and wave.vcd asset):
-**24 PASS / 0 FAIL / 0 SKIP** on amd64; **22 PASS / 0 FAIL / 2 SKIP** on
+empty-stdin self-contained, and wave.vcd which produces both a
+stdout-grading PASS and a separate asset-metadata PASS):
+**25 PASS / 0 FAIL / 0 SKIP** on amd64; **23 PASS / 0 FAIL / 2 SKIP** on
 arm64 (NASM and FreeBASIC are amd64-only upstream).
 
 Rspec tests in `spec/` are mostly upstream — Newton has not added
@@ -243,11 +244,16 @@ in `judge0.conf` explain each. Summary:
 - Docker Hub: `newtonschool/newton-judge0`
 - Current tag: **`0.67`** — adds Phase 3 submission-assets capture
   (Verilog 3005 declares `wave.vcd`; framework is language-agnostic).
-  Smoke target 24/0/0 on amd64.
-- Production runs from ECR (`405612465938.dkr.ecr.ap-south-1.amazonaws.com/judge0:0.56`),
-  pre-modernisation. Deploys are **single-image** (no docker-compose); the deployed
-  `newton-judge0:<tag>` connects to managed Postgres + managed Redis from the environment.
-- **Before bumping prod to 0.67:** prod nodes still run Amazon Linux 2 (cgroup v1).
-  Flip the karpenter NodeClass to AL2023 first — otherwise `docker-entrypoint.sh`'s
-  cgroup-v2 setup falls back silently to rlimit mode and you lose RSS-based limits.
+  Smoke target 25/0/0 on amd64.
+- Production runs `newton-judge0:0.67` from ECR
+  (`405612465938.dkr.ecr.ap-south-1.amazonaws.com/judge0`) as of 2026-05-05.
+  Smoke green against `https://judge0-public.newtonschool.co` (25/0/0 incl.
+  Phase 3 wave.vcd asset round-trip). Deploys are **single-image** (no
+  docker-compose); the deployed `newton-judge0:<tag>` connects to managed
+  Postgres + managed Redis from the environment.
+- **AL2 → AL2023 NodeClass flip is done.** The karpenter `code-compiler`
+  NodeClass moved to `amiFamily: AL2023` ahead of the 0.67 deploy, so
+  `docker-entrypoint.sh`'s cgroup-v2 setup is active in prod and the
+  RSS-based memory / `cpu.stat`-based time semantics work as designed.
+  Future image bumps inherit this — no per-bump prerequisite.
 - See `git log` for the 0.53 → 0.67 chronology if you need to bisect a regression.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,19 @@ language ids exist and what they invoke. Editing it requires a
   `tb.v:N: $finish called at T (1s)` epilogue (or use `$finish(0);` in
   the testbench to suppress that line at source). Full design rationale
   in `docs/superpowers/specs/2026-05-02-iverilog-integration-design.md`.
+- **Submission assets (Phase 3, new in 0.67).** Languages may declare
+  an `assets:` array in `active.rb` (Verilog 3005 declares `wave.vcd`
+  with regex `\.vcd$`). After `run_cmd` exits, `IsolateJob` calls
+  `AssetCapture` to glob the box for matching files and persist them
+  as `submission_assets` rows (base64 in a `text` column, capped per
+  declaration / `MAX_MAX_ASSET_SIZE`). Two-level decision: per-call
+  opt-out via `skip_assets: true` in the POST body, plus implicit
+  per-language opt-in (no `assets:` array → no capture work).
+  Validation runs at seed time (fails container boot on bad regex)
+  and via `bin/lint-active-rb` (CI gate). API: extended submission
+  GET returns asset metadata when `fields=...,assets`; bytes via
+  `GET /submissions/:token/assets/:logical_name`. Full design in
+  `docs/superpowers/specs/2026-05-05-submission-assets-design.md`.
 
 ## Build commands
 
@@ -159,10 +172,11 @@ binaries — Ruby version, gems via `bundle install`, etc. — need a rebuild).
 JUDGE0_URL=http://localhost:2358 ./bin/newton-smoke-test
 ```
 
-Submits a hello-world for every active language id. Expected (post-0.66
-with Verilog added; two cases — testbench-in-stdin and empty-stdin
-self-contained): **23 PASS / 0 FAIL / 0 SKIP** on amd64; **21 PASS /
-0 FAIL / 2 SKIP** on arm64 (NASM and FreeBASIC are amd64-only upstream).
+Submits a hello-world for every active language id. Expected (post-0.67
+with Phase 3 asset capture; three Verilog cases — testbench-in-stdin,
+empty-stdin self-contained, and wave.vcd asset):
+**24 PASS / 0 FAIL / 0 SKIP** on amd64; **22 PASS / 0 FAIL / 2 SKIP** on
+arm64 (NASM and FreeBASIC are amd64-only upstream).
 
 Rspec tests in `spec/` are mostly upstream — Newton has not added
 comprehensive specs. Don't rely on `bundle exec rspec` for end-to-end
@@ -183,6 +197,7 @@ in `judge0.conf` explain each. Summary:
 | `MAX_MAX_PROCESSES_AND_OR_THREADS` | 120 | **4096** | compile-time max |
 | `MAX_FILE_SIZE` | 1 MB | **1 GiB** | Go 1.23 binaries + Java class+jar bundles can exceed 1 MB |
 | `MAX_MAX_FILE_SIZE` | 4 MB | **2 GiB** | per-submission max |
+| `MAX_MAX_ASSET_SIZE` | – (new in 0.67) | **20480** (20 KB) | Phase 3 asset cap; clamps any per-language `max_size` |
 
 ## Common pitfalls
 
@@ -226,12 +241,13 @@ in `judge0.conf` explain each. Summary:
 ## Image is published as
 
 - Docker Hub: `newtonschool/newton-judge0`
-- Current tag: **`0.66`** — compiler base 0.29 (adds Icarus Verilog 13.0
-  for new language id 3005). Smoke target 22/0/0 on amd64.
+- Current tag: **`0.67`** — adds Phase 3 submission-assets capture
+  (Verilog 3005 declares `wave.vcd`; framework is language-agnostic).
+  Smoke target 24/0/0 on amd64.
 - Production runs from ECR (`405612465938.dkr.ecr.ap-south-1.amazonaws.com/judge0:0.56`),
   pre-modernisation. Deploys are **single-image** (no docker-compose); the deployed
   `newton-judge0:<tag>` connects to managed Postgres + managed Redis from the environment.
-- **Before bumping prod to 0.66:** prod nodes still run Amazon Linux 2 (cgroup v1).
+- **Before bumping prod to 0.67:** prod nodes still run Amazon Linux 2 (cgroup v1).
   Flip the karpenter NodeClass to AL2023 first — otherwise `docker-entrypoint.sh`'s
   cgroup-v2 setup falls back silently to rlimit mode and you lose RSS-based limits.
-- See `git log` for the 0.53 → 0.66 chronology if you need to bisect a regression.
+- See `git log` for the 0.53 → 0.67 chronology if you need to bisect a regression.

--- a/app/controllers/submission_assets_controller.rb
+++ b/app/controllers/submission_assets_controller.rb
@@ -1,0 +1,38 @@
+require "base64"
+
+class SubmissionAssetsController < ApplicationController
+  before_action :set_submission_and_asset, only: [:show]
+
+  # GET /submissions/:submission_token/assets/:logical_name
+  #
+  # Default: returns { "data": "<base64>" } JSON straight from the column.
+  # With Accept: application/octet-stream: decoded bytes as a download.
+  #
+  # Per docs/superpowers/specs/2026-05-05-submission-assets-design.md.
+  def show
+    if @asset.data.nil?
+      head :not_found
+      return
+    end
+
+    if request.headers["Accept"] == "application/octet-stream"
+      filename = @asset.source_filename.presence || @asset.logical_name
+      send_data(Base64.decode64(@asset.data),
+                type: "application/octet-stream",
+                disposition: "attachment",
+                filename: filename)
+    else
+      render json: { data: @asset.data }
+    end
+  end
+
+  private
+
+  def set_submission_and_asset
+    submission = Submission.find_by(token: params[:submission_token])
+    return head :not_found if submission.nil?
+
+    @asset = submission.submission_assets.find_by(logical_name: params[:logical_name])
+    return head :not_found if @asset.nil?
+  end
+end

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -179,7 +179,8 @@ class SubmissionsController < ApplicationController
       :callback_url,
       :additional_files,
       :enable_network,
-      :playground_hash
+      :playground_hash,
+      :skip_assets
     )
 
     submission_params[:additional_files] = Base64Service.decode(submission_params[:additional_files])

--- a/app/helpers/config.rb
+++ b/app/helpers/config.rb
@@ -31,6 +31,7 @@ module Config
   ALLOW_ENABLE_PER_PROCESS_AND_THREAD_MEMORY_LIMIT = ENV["ALLOW_ENABLE_PER_PROCESS_AND_THREAD_MEMORY_LIMIT"] != "false"
   MAX_FILE_SIZE = (ENV["MAX_FILE_SIZE"].presence || 1024).to_i
   MAX_MAX_FILE_SIZE = (ENV["MAX_MAX_FILE_SIZE"].presence || 4096).to_i
+  MAX_MAX_ASSET_SIZE = (ENV["MAX_MAX_ASSET_SIZE"].presence || 20480).to_i
   MAX_OPEN_FILES = (ENV["MAX_OPEN_FILES"].presence || 4096).to_i
   MAX_MAX_OPEN_FILES = (ENV["MAX_MAX_OPEN_FILES"].presence || 16384).to_i
   NUMBER_OF_RUNS = (ENV["NUMBER_OF_RUNS"].presence || 1).to_i
@@ -77,6 +78,7 @@ module Config
       "allow_enable_per_process_and_thread_memory_limit": ALLOW_ENABLE_PER_PROCESS_AND_THREAD_MEMORY_LIMIT,
       "max_file_size": MAX_FILE_SIZE,
       "max_max_file_size": MAX_MAX_FILE_SIZE,
+      "max_max_asset_size": MAX_MAX_ASSET_SIZE,
       "max_open_files": MAX_OPEN_FILES,
       "max_max_open_files": MAX_MAX_OPEN_FILES,
       "number_of_runs": NUMBER_OF_RUNS,

--- a/app/jobs/isolate_job.rb
+++ b/app/jobs/isolate_job.rb
@@ -36,6 +36,7 @@ class IsolateJob < ApplicationJob
       time << submission.time
       memory << submission.memory
 
+      capture_assets
       cleanup
       break if submission.status != Status.ac
     end
@@ -305,6 +306,26 @@ class IsolateJob < ApplicationJob
     end
     `isolate #{cgroups} -b #{box_id} --cleanup`
     raise "Cleanup of sandbox #{box_id} failed." if raise_exception && Dir.exists?(workdir)
+  end
+
+  # Phase 3 — capture language-declared artifacts (e.g. Verilog .vcd
+  # waveforms) from the box before cleanup wipes it. Two-level decision:
+  #   1. caller opt-out via submission.skip_assets
+  #   2. language opt-in via non-empty assets: array in active.rb
+  # Per docs/superpowers/specs/2026-05-05-submission-assets-design.md.
+  def capture_assets
+    return if submission.skip_assets
+    return if submission.language.assets.blank?
+
+    AssetCapture.new(
+      box_path:     boxdir,
+      submission:   submission,
+      declarations: submission.language.assets
+    ).call
+  rescue StandardError => e
+    # Capture failure must not break grading. Log and proceed; cleanup
+    # runs regardless via the caller's && chain.
+    Rails.logger.error("AssetCapture failed for submission #{submission.id}: #{e.class} #{e.message}")
   end
 
   def reset_metadata_file

--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -11,6 +11,8 @@
 #
 
 class Language < ApplicationRecord
+  serialize :assets
+
   validates :name, presence: true
   validates :source_file, :run_cmd, presence: true, unless: -> { is_project }
   default_scope { where(is_archived: false).order(name: :asc) }

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -78,6 +78,8 @@ class Submission < ApplicationRecord
   before_create :generate_token
   before_validation :set_defaults
 
+  has_many :submission_assets, dependent: :destroy
+
   enumeration :status
 
   default_scope { order(created_at: :desc) }

--- a/app/models/submission_asset.rb
+++ b/app/models/submission_asset.rb
@@ -1,0 +1,10 @@
+class SubmissionAsset < ApplicationRecord
+  belongs_to :submission
+
+  validates :logical_name, presence: true
+  validates :size_bytes,   numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+
+  # Rows with a non-null `error` represent a capture attempt that
+  # produced no usable bytes (e.g. exceeded MAX_MAX_ASSET_SIZE).
+  scope :with_data, -> { where(error: nil).where.not(data: nil) }
+end

--- a/app/serializers/submission_asset_serializer.rb
+++ b/app/serializers/submission_asset_serializer.rb
@@ -1,0 +1,7 @@
+class SubmissionAssetSerializer < ActiveModel::Serializer
+  # Metadata only — `data` is intentionally omitted.
+  # The bytes are surfaced via the dedicated endpoint
+  # GET /submissions/:submission_token/assets/:logical_name to keep
+  # typical submission JSON small.
+  attributes :logical_name, :source_filename, :size_bytes, :error, :error_detail
+end

--- a/app/serializers/submission_serializer.rb
+++ b/app/serializers/submission_serializer.rb
@@ -1,5 +1,5 @@
 class SubmissionSerializer < ActiveModel::Serializer
-  attributes((Submission.column_names + ["status", "language"] - ["id"]).collect(&:to_sym))
+  attributes((Submission.column_names + ["status", "language", "assets"] - ["id"]).collect(&:to_sym))
 
   def self.default_fields
     @@default_fields ||= [
@@ -51,6 +51,14 @@ class SubmissionSerializer < ActiveModel::Serializer
 
   def language
     ActiveModelSerializers::SerializableResource.new(object.language, { serializer: LanguageSerializer, fields: [:id, :name] })
+  end
+
+  # Phase 3 — array of asset metadata hashes (no `data`). Bytes are
+  # available via GET /submissions/:token/assets/:logical_name.
+  def assets
+    object.submission_assets.map do |a|
+      SubmissionAssetSerializer.new(a).attributes
+    end
   end
 
   def additional_files

--- a/app/services/asset_capture.rb
+++ b/app/services/asset_capture.rb
@@ -1,0 +1,86 @@
+require "base64"
+
+# Captures language-declared artifacts from the isolate sandbox box
+# and persists them as SubmissionAsset rows.
+#
+# Invoked by IsolateJob after run_cmd completes, before
+# `isolate --cleanup` wipes the box.
+#
+# Per docs/superpowers/specs/2026-05-05-submission-assets-design.md.
+class AssetCapture
+  def initialize(box_path:, submission:, declarations:)
+    @box_path     = box_path
+    @submission   = submission
+    @declarations = Array(declarations)
+  end
+
+  def call
+    @declarations.each { |d| capture_one(d) }
+  end
+
+  private
+
+  def capture_one(decl)
+    pattern = build_pattern(decl[:identification])
+    return if pattern.nil? # invalid regex — skip silently (validator catches at boot)
+
+    matched = first_matching_filename(pattern)
+    return if matched.nil? # no match — no row written
+
+    file_path     = File.join(@box_path, matched)
+    raw_size      = File.size(file_path)
+    effective_cap = compute_cap(decl[:max_size])
+
+    if raw_size > effective_cap
+      write_size_limit_row(decl, matched, raw_size, effective_cap)
+    else
+      write_data_row(decl, matched, file_path)
+    end
+  end
+
+  def first_matching_filename(pattern)
+    Dir.entries(@box_path)
+       .select { |f| File.file?(File.join(@box_path, f)) && pattern.match?(f) }
+       .sort
+       .first
+  end
+
+  def build_pattern(identification)
+    Regexp.new(identification.to_s)
+  rescue RegexpError
+    nil
+  end
+
+  def compute_cap(declared)
+    ceiling = Config::MAX_MAX_ASSET_SIZE
+    [declared || ceiling, ceiling].min
+  end
+
+  def write_size_limit_row(decl, matched, raw_size, effective_cap)
+    @submission.submission_assets.create!(
+      logical_name:    decl[:name],
+      source_filename: matched,
+      size_bytes:      raw_size,
+      error:           "size_limit_exceeded",
+      error_detail:    "#{raw_size} bytes exceeds #{effective_cap} byte cap"
+    )
+  end
+
+  def write_data_row(decl, matched, file_path)
+    bytes = File.binread(file_path)
+    @submission.submission_assets.create!(
+      logical_name:    decl[:name],
+      source_filename: matched,
+      size_bytes:      bytes.bytesize,
+      data:            Base64.strict_encode64(bytes)
+    )
+  rescue SystemCallError => e
+    @submission.submission_assets.create!(
+      logical_name:    decl[:name],
+      source_filename: matched,
+      size_bytes:      0,
+      error:           "read_error",
+      error_detail:    e.message
+    )
+  end
+end

--- a/bin/lint-active-rb
+++ b/bin/lint-active-rb
@@ -1,0 +1,28 @@
+#!/usr/bin/env ruby
+# bin/lint-active-rb — schema check for db/languages/active.rb
+#
+# Usage:
+#   bundle exec ruby bin/lint-active-rb
+#   ./bin/lint-active-rb                    # if executable
+#
+# Intended to run in CI before `docker push` so malformed asset
+# declarations are caught at PR time, not at container boot. The same
+# AssetValidator logic also runs in db/seeds.rb (Layer 1, runtime
+# safety) — this script is the Layer 2 / pre-merge gate.
+#
+# Per docs/superpowers/specs/2026-05-05-submission-assets-design.md.
+
+require_relative "../db/languages/active"
+require_relative "../db/languages/asset_validator"
+
+errors = @languages.flat_map { |lang| AssetValidator.validate_language(lang) }
+
+if errors.empty?
+  decl_count = @languages.sum { |l| Array(l[:assets]).size }
+  puts "OK — #{@languages.count} languages, #{decl_count} asset declarations validated."
+  exit 0
+else
+  warn "active.rb has #{errors.size} problem(s):"
+  errors.each { |e| warn "  - #{e}" }
+  exit 1
+end

--- a/bin/newton-postman.json
+++ b/bin/newton-postman.json
@@ -1,7 +1,7 @@
 {
   "info": {
     "_postman_id": "f3a8c2e1-9d4b-4b6f-a7e2-5c1d8e9f0a01",
-    "name": "Newton Judge0 — All Languages (0.66)",
+    "name": "Newton Judge0 — All Languages (0.67)",
     "description": "End-to-end smoke for every active language id in db/languages/active.rb.\nMirrors bin/newton-smoke-test as importable Postman requests.\n\nUsage:\n  1. Import this file in Postman.\n  2. Edit the collection variable `base_url` to point at your environment\n     (e.g. http://localhost:2358 for dev, https://judge0.newtonschool.co for prod).\n  3. Run individual requests, or use the Collection Runner to execute all.\n\nAll requests use `?wait=true` so the response is the final submission result\n(no polling loop). Each request has a Tests script that asserts:\n  - HTTP 201\n  - status.description === \"Accepted\"\n  - stdout contains \"Hello, Newton!\"\n\nOnly currently-active languages are tested here. See db/languages/archived.rb\nfor retired ids — submitting any of those returns a 422 'language is archived'.",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },

--- a/bin/newton-smoke-test
+++ b/bin/newton-smoke-test
@@ -85,6 +85,54 @@ t_stdin() {
     _check_resp "$name" "$lid" "$expected" "$resp"
 }
 
+# t_stdin_with_asset <name> <language_id> <source_code> <stdin> <expected_substring> <asset_logical_name>
+# Phase 3 — same as t_stdin, but also asserts the named asset is captured:
+#   1. submission GET (with fields=...,assets) returns metadata with size_bytes>0 and error=null
+#   2. dedicated bytes endpoint returns HTTP 200
+# Adds an additional PASS/FAIL row beyond the stdout grading check, so a
+# Verilog problem with $dumpfile contributes 2 entries to the smoke summary.
+t_stdin_with_asset() {
+    local name="$1" lid="$2" src="$3" stdin="$4" expected="$5" asset_name="$6"
+    local payload resp token assets_json size err bytes_status
+
+    payload="$(jq -nc --arg sc "$src" --arg si "$stdin" --argjson lid "$lid" \
+        '{language_id:$lid, source_code:$sc, stdin:$si}')"
+    resp="$(curl -s -X POST "${URL}/submissions?wait=true&fields=token,stdout,stderr,status,message,compile_output,assets" \
+        -H 'Content-Type: application/json' -d "$payload")"
+
+    token="$(echo "$resp" | jq -r '.token // empty')"
+    _check_resp "$name" "$lid" "$expected" "$resp"
+
+    if [[ -z "$token" ]]; then
+        printf "  \033[31mFAIL\033[0m  %s asset (no token returned)\n" "$name"
+        FAIL=$((FAIL+1))
+        FAILED+=("$name asset (no token)")
+        return
+    fi
+
+    assets_json="$(echo "$resp" | jq -c --arg n "$asset_name" '.assets // [] | map(select(.logical_name == $n)) | .[0] // {}')"
+    size="$(echo "$assets_json" | jq -r '.size_bytes // 0')"
+    err="$(echo "$assets_json" | jq -r '.error // empty')"
+
+    if [[ -n "$err" || "$size" -le 0 ]]; then
+        printf "  \033[31mFAIL\033[0m  %s asset metadata  size=%s err=%s\n" "$name" "$size" "$err"
+        FAIL=$((FAIL+1))
+        FAILED+=("$name asset metadata (size=$size err=$err)")
+        return
+    fi
+
+    bytes_status="$(curl -s -o /dev/null -w '%{http_code}' "${URL}/submissions/$token/assets/$asset_name")"
+    if [[ "$bytes_status" != "200" ]]; then
+        printf "  \033[31mFAIL\033[0m  %s asset bytes endpoint http=%s\n" "$name" "$bytes_status"
+        FAIL=$((FAIL+1))
+        FAILED+=("$name asset bytes (http $bytes_status)")
+        return
+    fi
+
+    printf "  \033[32mPASS\033[0m  %s asset (size=%s)\n" "$name" "$size"
+    PASS=$((PASS+1))
+}
+
 _check_resp() {
     local name="$1" lid="$2" expected="$3" resp="$4"
     local status stdout err
@@ -267,6 +315,31 @@ SRC_VERILOG_SELF='module testbench;
   end
 endmodule'
 
+# Verilog 3005 — variant with $dumpfile/$dumpvars that drives Phase 3
+# asset capture. AND-gate DUT + testbench that produces wave.vcd
+# alongside the truth table on stdout. The smoke driver
+# (t_stdin_with_asset) verifies both the stdout grading AND that the
+# wave.vcd asset shows up via /submissions/:token/assets/wave.vcd.
+SRC_VERILOG_WAVE='module and_gate(input wire a, input wire b, output wire y);
+  assign y = a & b;
+endmodule'
+
+STDIN_VERILOG_WAVE='`timescale 1ns/1ps
+module and_gate_tb;
+  reg a; reg b; wire y;
+  and_gate uut (.a(a), .b(b), .y(y));
+  initial begin
+    $dumpfile("wave.vcd");
+    $dumpvars(0, and_gate_tb);
+    a = 0; b = 0; #10;
+    a = 0; b = 1; #10;
+    a = 1; b = 0; #10;
+    a = 1; b = 1; #10;
+    $display("Hello, Newton!");
+    $finish(0);
+  end
+endmodule'
+
 # ────────────────────────────────────────────────────────────────────────
 # 0.59 trim: 25 active languages moved to archived.rb (compiler toolchains
 # dropped from newtonschool/judge0-newton-compiler:0.27). The "Archived"
@@ -359,6 +432,13 @@ t_stdin "Verilog Icarus 13.0 (3005)" 3005 "$SRC_VERILOG" "$STDIN_VERILOG" "$EXPE
 # DUT's own testbench module. Confirms run_cmd is robust to missing
 # testbench, which can happen if the platform UI doesn't populate stdin.
 t_stdin "Verilog 3005 self-contained / empty stdin" 3005 "$SRC_VERILOG_SELF" "" "$EXPECTED"
+
+# Verilog with waveform (Phase 3 asset capture). Testbench includes
+# $dumpfile + $dumpvars; we expect a wave.vcd asset to be captured and
+# surfaced via /submissions/:token/assets/wave.vcd. Adds two PASS
+# entries to the smoke summary (stdout grading + asset check).
+t_stdin_with_asset "Verilog 3005 with wave.vcd asset" 3005 \
+    "$SRC_VERILOG_WAVE" "$STDIN_VERILOG_WAVE" "$EXPECTED" "wave.vcd"
 
 # Archived languages are intentionally not tested here — the smoke test
 # verifies the *currently active* surface. See db/languages/archived.rb

--- a/bin/newton-smoke-test
+++ b/bin/newton-smoke-test
@@ -437,7 +437,7 @@ t_stdin "Verilog 3005 self-contained / empty stdin" 3005 "$SRC_VERILOG_SELF" "" 
 # $dumpfile + $dumpvars; we expect a wave.vcd asset to be captured and
 # surfaced via /submissions/:token/assets/wave.vcd. Adds two PASS
 # entries to the smoke summary (stdout grading + asset check).
-t_stdin_with_asset "Verilog 3005 with wave.vcd asset" 3005 \
+t_stdin_with_asset "Verilog 3005 with wave.vcd" 3005 \
     "$SRC_VERILOG_WAVE" "$STDIN_VERILOG_WAVE" "$EXPECTED" "wave.vcd"
 
 # Archived languages are intentionally not tested here — the smoke test

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,15 @@ Rails.application.routes.draw do
   resources :submissions, only: [:index, :show, :create, :destroy], param: :token do
     post 'batch', to: 'submissions#batch_create', on: :collection
     get 'batch', to: 'submissions#batch_show', on: :collection
+
+    # Phase 3 — asset bytes endpoint. logical_name regex allows dots
+    # in filenames (e.g. 'wave.vcd') without Rails treating them as
+    # format separators.
+    # See docs/superpowers/specs/2026-05-05-submission-assets-design.md.
+    get 'assets/:logical_name',
+        to: 'submission_assets#show',
+        constraints: { logical_name: %r{[^/]+} },
+        as: :asset
   end
 
   resources :languages, only: [:index, :show] do

--- a/db/languages/active.rb
+++ b/db/languages/active.rb
@@ -203,6 +203,15 @@
     is_archived: false,
     source_file: "main.v",
     compile_cmd: "/usr/local/iverilog-13.0/bin/iverilog -g2012 -tnull %s main.v",
-    run_cmd: "/bin/cat > tb.v && /usr/local/iverilog-13.0/bin/iverilog -g2012 -o sim.vvp main.v tb.v && /usr/local/iverilog-13.0/bin/vvp sim.vvp"
+    run_cmd: "/bin/cat > tb.v && /usr/local/iverilog-13.0/bin/iverilog -g2012 -o sim.vvp main.v tb.v && /usr/local/iverilog-13.0/bin/vvp sim.vvp",
+    # Phase 3 asset: capture .vcd waveforms produced by testbenches that
+    # call $dumpfile/$dumpvars. Author opt-in is implicit (testbench
+    # without $dumpfile produces no .vcd, regex matches nothing, no row).
+    # 20 KB cap targets DSA-scale designs; authors needing larger dumps
+    # must scope their $dumpvars (e.g. $dumpvars(1, testbench.dut)).
+    # See docs/superpowers/specs/2026-05-05-submission-assets-design.md.
+    assets: [
+      { name: "wave.vcd", identification: '\.vcd$', max_size: 20480 }
+    ]
   }
 ]

--- a/db/languages/asset_validator.rb
+++ b/db/languages/asset_validator.rb
@@ -1,0 +1,37 @@
+# Pure-Ruby validator for db/languages/active.rb asset declarations.
+#
+# Used by:
+#   - db/seeds.rb       — runs at container boot, fails fast on bad data
+#   - bin/lint-active-rb — runs in CI, catches problems at PR time
+#
+# Deliberately depends on no Rails internals so the lint script can
+# run without booting Rails (faster CI, fewer moving parts).
+#
+# Per docs/superpowers/specs/2026-05-05-submission-assets-design.md.
+module AssetValidator
+  module_function
+
+  # Returns Array<String> of error messages (empty array on valid).
+  def validate_language(lang)
+    errors = []
+    Array(lang[:assets]).each_with_index do |asset, i|
+      prefix = "lang #{lang[:id]} (#{lang[:name].inspect}) asset[#{i}]"
+
+      errors << "#{prefix}: missing :name"           if asset[:name].to_s.empty?
+      errors << "#{prefix}: missing :identification" if asset[:identification].to_s.empty?
+
+      if asset[:identification]
+        begin
+          Regexp.new(asset[:identification])
+        rescue RegexpError => e
+          errors << "#{prefix}: identification #{asset[:identification].inspect} not valid regex — #{e.message}"
+        end
+      end
+
+      if asset.key?(:max_size) && !(asset[:max_size].is_a?(Integer) && asset[:max_size] > 0)
+        errors << "#{prefix}: max_size must be positive Integer (got #{asset[:max_size].inspect})"
+      end
+    end
+    errors
+  end
+end

--- a/db/migrate/20260505000001_create_submission_assets.rb
+++ b/db/migrate/20260505000001_create_submission_assets.rb
@@ -1,0 +1,18 @@
+class CreateSubmissionAssets < ActiveRecord::Migration[5.2]
+  def change
+    create_table :submission_assets do |t|
+      t.references :submission,
+                   foreign_key: { on_delete: :cascade },
+                   null: false
+      t.string :logical_name,    null: false
+      t.string :source_filename
+      t.text :data
+      t.integer :size_bytes,     null: false
+      t.string :error
+      t.text :error_detail
+      t.timestamps
+    end
+
+    add_index :submission_assets, [:submission_id, :logical_name]
+  end
+end

--- a/db/migrate/20260505000002_add_skip_assets_to_submissions.rb
+++ b/db/migrate/20260505000002_add_skip_assets_to_submissions.rb
@@ -1,0 +1,5 @@
+class AddSkipAssetsToSubmissions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :submissions, :skip_assets, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20260505000003_add_assets_to_languages.rb
+++ b/db/migrate/20260505000003_add_assets_to_languages.rb
@@ -1,0 +1,5 @@
+class AddAssetsToLanguages < ActiveRecord::Migration[5.2]
+  def change
+    add_column :languages, :assets, :text
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,13 @@
 require_relative 'languages/archived'
 require_relative 'languages/active'
+require_relative 'languages/asset_validator'
+
+# Phase 3 schema check — fail-fast on malformed `assets:` declarations.
+# Per docs/superpowers/specs/2026-05-05-submission-assets-design.md.
+asset_errors = @languages.flat_map { |lang| AssetValidator.validate_language(lang) }
+if asset_errors.any?
+  raise "active.rb asset validation failed:\n  " + asset_errors.join("\n  ")
+end
 
 ActiveRecord::Base.transaction do
   Language.unscoped.delete_all

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -19,6 +19,7 @@ ActiveRecord::Base.transaction do
       source_file: language[:source_file],
       compile_cmd: language[:compile_cmd],
       run_cmd: language[:run_cmd],
+      assets: language[:assets],
     )
   end
 end

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -13,9 +13,9 @@ services:
   judge0:
     # Built from NewtonDockerfile. Build locally before bringing the stack up:
     #   docker buildx build --platform linux/arm64 \
-    #       -f NewtonDockerfile -t newtonschool/newton-judge0:0.66 --load .
+    #       -f NewtonDockerfile -t newtonschool/newton-judge0:0.67 --load .
     # (use --platform linux/amd64 on EC2 / prod build hosts)
-    image: newtonschool/newton-judge0:0.66
+    image: newtonschool/newton-judge0:0.67
     environment:
       VIRTUAL_HOST: judge0.local
     volumes:

--- a/docs/superpowers/plans/2026-05-05-submission-assets.md
+++ b/docs/superpowers/plans/2026-05-05-submission-assets.md
@@ -1,0 +1,1353 @@
+# Submission Assets Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Capture artifacts (`.vcd` waveforms first; mechanism is language-agnostic) produced inside the isolate sandbox during a submission run, persist them in a new `submission_assets` table, and surface them via the judge0 API alongside `stdout`/`stderr`/`status`.
+
+**Architecture:** A language definition in `db/languages/active.rb` may declare an `assets` array (each entry: `{ name:, identification:, max_size? }`, where `identification` is a Ruby regex). After `IsolateJob` runs `run_cmd` and before `isolate --cleanup` wipes the box, an `AssetCapture` service iterates the language's asset declarations, regex-matches files in the box, and writes one `SubmissionAsset` row per match (data base64-encoded into a `text` column, capped at `MAX_MAX_ASSET_SIZE`). Submissions get a new `skip_assets` boolean column for per-call opt-out. Two API surfaces: extended `GET /submissions/:token` (asset metadata when `fields=...,assets`) and a new `GET /submissions/:token/assets/:logical_name` (asset bytes).
+
+**Tech Stack:** Rails 5.2, Ruby 2.7.8, Postgres 13, ActiveModel::Serializer for the API surface. No new gems.
+
+**Spec:** `docs/superpowers/specs/2026-05-05-submission-assets-design.md`
+
+---
+
+## File Structure
+
+### Created files
+
+| Path | Responsibility |
+|---|---|
+| `db/migrate/20260505000001_create_submission_assets.rb` | New `submission_assets` table with FK + cascade delete |
+| `db/migrate/20260505000002_add_skip_assets_to_submissions.rb` | Boolean column on `submissions` |
+| `app/models/submission_asset.rb` | ActiveRecord model |
+| `app/serializers/submission_asset_serializer.rb` | API representation (metadata only — `data` excluded) |
+| `app/services/asset_capture.rb` | Capture logic: iterate declarations, match regex, read file, write row |
+| `db/languages/asset_validator.rb` | Plain-Ruby validator for `assets:` declarations (no Rails dep) |
+| `app/controllers/submission_assets_controller.rb` | Bytes endpoint |
+| `bin/lint-active-rb` | Standalone CLI calling `AssetValidator` against `active.rb` |
+| `spec/services/asset_capture_spec.rb` | Unit tests for capture |
+| `spec/db/languages/asset_validator_spec.rb` | Unit tests for validator |
+
+### Modified files
+
+| Path | What changes |
+|---|---|
+| `judge0.conf` | New `MAX_MAX_ASSET_SIZE` knob |
+| `app/helpers/config.rb` | New `Config::MAX_MAX_ASSET_SIZE` constant |
+| `app/models/submission.rb` | `has_many :submission_assets`; `skip_assets` allowed in mass-assignment |
+| `app/serializers/submission_serializer.rb` | New `assets` attribute returning metadata array |
+| `app/jobs/isolate_job.rb` | Call `AssetCapture` after `run`, before `cleanup` |
+| `app/controllers/submissions_controller.rb` | Accept `skip_assets` in POST body |
+| `db/languages/active.rb` | Verilog 3005 entry gets `assets:` array |
+| `db/seeds.rb` | Run `AssetValidator` before insert |
+| `config/routes.rb` | New nested route for asset bytes |
+| `bin/newton-smoke-test` | Verify asset metadata in Verilog smoke response |
+| `CLAUDE.md` | Document the feature in Per-language tuning + Image is published as |
+
+---
+
+## Task 1: Create `submission_assets` table migration
+
+**Files:**
+- Create: `db/migrate/20260505000001_create_submission_assets.rb`
+
+- [ ] **Step 1.1: Write the migration**
+
+```ruby
+class CreateSubmissionAssets < ActiveRecord::Migration[5.2]
+  def change
+    create_table :submission_assets do |t|
+      t.references :submission,
+                   foreign_key: { on_delete: :cascade },
+                   null: false
+      t.string :logical_name,    null: false
+      t.string :source_filename
+      t.text :data                            # base64-encoded bytes; null when error set
+      t.integer :size_bytes,     null: false  # raw byte size of the matched file
+      t.string :error                         # "size_limit_exceeded" | "read_error" | nil
+      t.text :error_detail
+      t.timestamps
+    end
+
+    add_index :submission_assets, [:submission_id, :logical_name]
+  end
+end
+```
+
+- [ ] **Step 1.2: Run the migration**
+
+Run inside the judge0 container:
+```bash
+docker compose -f docker-compose.dev.yml exec judge0 bash -c 'cd /api && rake db:migrate'
+```
+Expected: `== CreateSubmissionAssets: migrated (...)`. The table appears in `\dt` output.
+
+- [ ] **Step 1.3: Sanity-check the schema**
+
+```bash
+docker compose -f docker-compose.dev.yml exec db psql -U judge0 -d judge0 -c '\d submission_assets'
+```
+Expected: columns include `submission_id`, `logical_name`, `source_filename`, `data`, `size_bytes`, `error`, `error_detail`, `created_at`, `updated_at`. Index on `(submission_id, logical_name)`.
+
+- [ ] **Step 1.4: Commit**
+
+```bash
+git add db/migrate/20260505000001_create_submission_assets.rb db/schema.rb
+git commit -m "Add submission_assets table"
+```
+
+---
+
+## Task 2: Add `skip_assets` column to submissions
+
+**Files:**
+- Create: `db/migrate/20260505000002_add_skip_assets_to_submissions.rb`
+
+- [ ] **Step 2.1: Write the migration**
+
+```ruby
+class AddSkipAssetsToSubmissions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :submissions, :skip_assets, :boolean, default: false, null: false
+  end
+end
+```
+
+- [ ] **Step 2.2: Run the migration**
+
+```bash
+docker compose -f docker-compose.dev.yml exec judge0 bash -c 'cd /api && rake db:migrate'
+```
+Expected: `== AddSkipAssetsToSubmissions: migrated (...)`.
+
+- [ ] **Step 2.3: Verify the column**
+
+```bash
+docker compose -f docker-compose.dev.yml exec db psql -U judge0 -d judge0 -c '\d submissions' | grep skip_assets
+```
+Expected: `skip_assets | boolean | not null default false`.
+
+- [ ] **Step 2.4: Commit**
+
+```bash
+git add db/migrate/20260505000002_add_skip_assets_to_submissions.rb db/schema.rb
+git commit -m "Add skip_assets column to submissions"
+```
+
+---
+
+## Task 3: Add `MAX_MAX_ASSET_SIZE` to Config and judge0.conf
+
+**Files:**
+- Modify: `app/helpers/config.rb`
+- Modify: `judge0.conf`
+
+- [ ] **Step 3.1: Add the constant to `Config`**
+
+In `app/helpers/config.rb`, add after the existing `MAX_MAX_*` constants (alongside `MAX_MAX_PROCESSES_AND_OR_THREADS`):
+
+```ruby
+  MAX_MAX_ASSET_SIZE = (ENV["MAX_MAX_ASSET_SIZE"].presence || 20480).to_i
+```
+
+- [ ] **Step 3.2: Add the env knob to `judge0.conf`**
+
+Append to `judge0.conf` (find the section that has `MAX_MAX_FILE_SIZE` and add a new section beneath it):
+
+```
+# Hard ceiling on per-asset size (bytes). Used as both:
+#   - the default cap when a language asset declaration omits :max_size
+#   - the absolute clamp on any per-language max_size (a language
+#     cannot exceed this; only ask for less)
+# Mirrors the role of MAX_MAX_MEMORY_LIMIT / MAX_MAX_FILE_SIZE.
+MAX_MAX_ASSET_SIZE=20480
+```
+
+- [ ] **Step 3.3: Reload config and verify**
+
+The Rails container loads config on boot. Restart the judge0 service:
+```bash
+docker compose -f docker-compose.dev.yml restart judge0
+docker compose -f docker-compose.dev.yml exec judge0 bash -c 'source /api/scripts/load-config; echo "MAX_MAX_ASSET_SIZE=$MAX_MAX_ASSET_SIZE"'
+```
+Expected: `MAX_MAX_ASSET_SIZE=20480`.
+
+- [ ] **Step 3.4: Commit**
+
+```bash
+git add app/helpers/config.rb judge0.conf
+git commit -m "Add MAX_MAX_ASSET_SIZE config knob"
+```
+
+---
+
+## Task 4: Create `SubmissionAsset` model and association
+
+**Files:**
+- Create: `app/models/submission_asset.rb`
+- Modify: `app/models/submission.rb`
+
+- [ ] **Step 4.1: Write the model**
+
+`app/models/submission_asset.rb`:
+```ruby
+class SubmissionAsset < ApplicationRecord
+  belongs_to :submission
+
+  validates :logical_name,  presence: true
+  validates :size_bytes,    numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+
+  # Convenience: rows with non-null `error` represent a capture attempt that
+  # produced no bytes (e.g. exceeded MAX_MAX_ASSET_SIZE).
+  scope :with_data, -> { where(error: nil).where.not(data: nil) }
+end
+```
+
+- [ ] **Step 4.2: Add the association to Submission**
+
+In `app/models/submission.rb`, find the model body and add after the existing associations (look for the `belongs_to :status` / `belongs_to :language` lines):
+
+```ruby
+  has_many :submission_assets, dependent: :destroy
+```
+
+Note: cascade on the DB side is already set; the `dependent: :destroy` keeps the Rails layer informed for callbacks/queries.
+
+- [ ] **Step 4.3: Sanity-check via Rails console**
+
+```bash
+docker compose -f docker-compose.dev.yml exec judge0 bash -c 'cd /api && rails console <<<"puts SubmissionAsset.column_names.inspect"'
+```
+Expected: array including `"logical_name"`, `"data"`, `"size_bytes"`, `"error"`, `"submission_id"`.
+
+- [ ] **Step 4.4: Commit**
+
+```bash
+git add app/models/submission_asset.rb app/models/submission.rb
+git commit -m "Add SubmissionAsset model + association"
+```
+
+---
+
+## Task 5: Create `AssetValidator` (no Rails dependency)
+
+**Files:**
+- Create: `db/languages/asset_validator.rb`
+- Create: `spec/db/languages/asset_validator_spec.rb`
+
+- [ ] **Step 5.1: Write the failing tests**
+
+`spec/db/languages/asset_validator_spec.rb`:
+```ruby
+require "rails_helper"
+require_relative "../../../db/languages/asset_validator"
+
+RSpec.describe AssetValidator do
+  describe ".validate_language" do
+    let(:lang) { { id: 9999, name: "Test Lang" } }
+
+    it "passes when no :assets array is present" do
+      errors = described_class.validate_language(lang)
+      expect(errors).to be_empty
+    end
+
+    it "passes for a well-formed asset" do
+      lang[:assets] = [{ name: "wave.vcd", identification: '\.vcd$', max_size: 20480 }]
+      errors = described_class.validate_language(lang)
+      expect(errors).to be_empty
+    end
+
+    it "errors when :name is missing" do
+      lang[:assets] = [{ identification: '\.vcd$' }]
+      errors = described_class.validate_language(lang)
+      expect(errors).to include(a_string_including("missing :name"))
+    end
+
+    it "errors when :identification is missing" do
+      lang[:assets] = [{ name: "wave.vcd" }]
+      errors = described_class.validate_language(lang)
+      expect(errors).to include(a_string_including("missing :identification"))
+    end
+
+    it "errors when :identification is not a valid regex" do
+      lang[:assets] = [{ name: "wave.vcd", identification: '[unclosed' }]
+      errors = described_class.validate_language(lang)
+      expect(errors).to include(a_string_including("not valid regex"))
+    end
+
+    it "errors when :max_size is not a positive Integer" do
+      lang[:assets] = [{ name: "wave.vcd", identification: '\.vcd$', max_size: -1 }]
+      errors = described_class.validate_language(lang)
+      expect(errors).to include(a_string_including("max_size must be positive Integer"))
+
+      lang[:assets] = [{ name: "wave.vcd", identification: '\.vcd$', max_size: "20480" }]
+      errors = described_class.validate_language(lang)
+      expect(errors).to include(a_string_including("max_size must be positive Integer"))
+    end
+  end
+end
+```
+
+- [ ] **Step 5.2: Run the test, verify it fails**
+
+```bash
+docker compose -f docker-compose.dev.yml exec judge0 bash -c 'cd /api && bundle exec rspec spec/db/languages/asset_validator_spec.rb'
+```
+Expected: load error or NameError because `AssetValidator` doesn't exist yet.
+
+- [ ] **Step 5.3: Implement the validator**
+
+`db/languages/asset_validator.rb`:
+```ruby
+# Pure-Ruby validator for db/languages/active.rb asset declarations.
+# Used by db/seeds.rb (at container boot) and bin/lint-active-rb (CI).
+# Deliberately depends on no Rails internals so the lint script can
+# run without booting Rails.
+module AssetValidator
+  module_function
+
+  # Returns Array<String> of error messages (empty on valid).
+  def validate_language(lang)
+    errors = []
+    Array(lang[:assets]).each_with_index do |asset, i|
+      prefix = "lang #{lang[:id]} (#{lang[:name].inspect}) asset[#{i}]"
+
+      errors << "#{prefix}: missing :name"           if asset[:name].to_s.empty?
+      errors << "#{prefix}: missing :identification" if asset[:identification].to_s.empty?
+
+      if asset[:identification]
+        begin
+          Regexp.new(asset[:identification])
+        rescue RegexpError => e
+          errors << "#{prefix}: identification #{asset[:identification].inspect} not valid regex — #{e.message}"
+        end
+      end
+
+      if asset.key?(:max_size) && !(asset[:max_size].is_a?(Integer) && asset[:max_size] > 0)
+        errors << "#{prefix}: max_size must be positive Integer (got #{asset[:max_size].inspect})"
+      end
+    end
+    errors
+  end
+end
+```
+
+- [ ] **Step 5.4: Run tests, verify all pass**
+
+```bash
+docker compose -f docker-compose.dev.yml exec judge0 bash -c 'cd /api && bundle exec rspec spec/db/languages/asset_validator_spec.rb'
+```
+Expected: 6 examples, 0 failures.
+
+- [ ] **Step 5.5: Commit**
+
+```bash
+git add db/languages/asset_validator.rb spec/db/languages/asset_validator_spec.rb
+git commit -m "Add AssetValidator for active.rb asset declarations"
+```
+
+---
+
+## Task 6: Wire `AssetValidator` into `db/seeds.rb`
+
+**Files:**
+- Modify: `db/seeds.rb`
+
+- [ ] **Step 6.1: Find the load point**
+
+Open `db/seeds.rb`. It loads `active.rb` and `archived.rb` then iterates `@languages` to insert/update Language records. We add the validation pass between load and insert.
+
+- [ ] **Step 6.2: Add the validation call**
+
+Near the top of `db/seeds.rb`, add the require:
+```ruby
+require_relative "languages/asset_validator"
+```
+
+After `@languages` is populated (after both `require_relative "languages/active"` and `require_relative "languages/archived"`), add the validation block:
+
+```ruby
+# Schema check — fail-fast on malformed asset declarations.
+asset_errors = @languages.flat_map { |lang| AssetValidator.validate_language(lang) }
+if asset_errors.any?
+  raise "active.rb asset validation failed:\n  #{asset_errors.join("\n  ")}"
+end
+```
+
+- [ ] **Step 6.3: Run seeds and verify it still passes**
+
+```bash
+docker compose -f docker-compose.dev.yml exec judge0 bash -c 'cd /api && rake db:seed'
+```
+Expected: completes without raising. (No language has `:assets` yet, so the validator returns empty errors for all.)
+
+- [ ] **Step 6.4: Negative test — temporarily inject a bad declaration**
+
+Temporarily edit `db/languages/active.rb`, add a broken asset to (say) the Bash entry: `assets: [{ name: "x", identification: "[unclosed" }]`.
+
+Run seed again:
+```bash
+docker compose -f docker-compose.dev.yml exec judge0 bash -c 'cd /api && rake db:seed' 2>&1 | tail -3
+```
+Expected: `active.rb asset validation failed: ... not valid regex — ...`. Then **revert the temporary edit**.
+
+- [ ] **Step 6.5: Commit**
+
+```bash
+git add db/seeds.rb
+git commit -m "Validate active.rb asset declarations at seed time"
+```
+
+---
+
+## Task 7: Standalone `bin/lint-active-rb` script
+
+**Files:**
+- Create: `bin/lint-active-rb`
+
+- [ ] **Step 7.1: Write the script**
+
+`bin/lint-active-rb`:
+```ruby
+#!/usr/bin/env ruby
+# bin/lint-active-rb — schema check for db/languages/active.rb
+#
+# Usage:
+#   bundle exec ruby bin/lint-active-rb
+#
+# Intended to run in CI before docker push so malformed asset
+# declarations are caught at PR time, not at container boot.
+
+require_relative "../db/languages/active"
+require_relative "../db/languages/asset_validator"
+
+errors = @languages.flat_map { |lang| AssetValidator.validate_language(lang) }
+
+if errors.empty?
+  decl_count = @languages.sum { |l| Array(l[:assets]).size }
+  puts "OK — #{@languages.count} languages, #{decl_count} asset declarations validated."
+  exit 0
+else
+  warn "active.rb has #{errors.size} problem(s):"
+  errors.each { |e| warn "  - #{e}" }
+  exit 1
+end
+```
+
+- [ ] **Step 7.2: Make it executable**
+
+```bash
+chmod +x bin/lint-active-rb
+```
+
+- [ ] **Step 7.3: Run it locally**
+
+```bash
+docker compose -f docker-compose.dev.yml exec judge0 bash -c 'cd /api && ruby bin/lint-active-rb'
+```
+Expected: `OK — 21 languages, 0 asset declarations validated.` (No assets declared yet — Verilog gets one in Task 11.)
+
+- [ ] **Step 7.4: Commit**
+
+```bash
+git add bin/lint-active-rb
+git commit -m "Add bin/lint-active-rb CLI for asset declaration linting"
+```
+
+---
+
+## Task 8: `AssetCapture` service (TDD)
+
+**Files:**
+- Create: `app/services/asset_capture.rb`
+- Create: `spec/services/asset_capture_spec.rb`
+
+- [ ] **Step 8.1: Write the failing tests**
+
+`spec/services/asset_capture_spec.rb`:
+```ruby
+require "rails_helper"
+require "tmpdir"
+require "fileutils"
+require "base64"
+
+RSpec.describe AssetCapture do
+  let(:submission) { Submission.create!(language: Language.first, source_code: "x") }
+
+  around do |example|
+    Dir.mktmpdir do |dir|
+      @box = dir
+      example.run
+    end
+  end
+
+  def declaration(overrides = {})
+    { name: "wave.vcd", identification: '\.vcd$', max_size: 20480 }.merge(overrides)
+  end
+
+  it "writes no row when no file matches the regex" do
+    File.write(File.join(@box, "main.v"), "module x; endmodule")
+    described_class.new(box_path: @box, submission: submission, declarations: [declaration]).call
+    expect(submission.submission_assets.count).to eq(0)
+  end
+
+  it "stores base64 data and raw size when file is within cap" do
+    raw = "$date\nFri\n$end\n"  # 18 bytes
+    File.write(File.join(@box, "wave.vcd"), raw)
+
+    described_class.new(box_path: @box, submission: submission, declarations: [declaration]).call
+
+    a = submission.submission_assets.first
+    expect(a.logical_name).to eq("wave.vcd")
+    expect(a.source_filename).to eq("wave.vcd")
+    expect(a.size_bytes).to eq(raw.bytesize)
+    expect(a.error).to be_nil
+    expect(Base64.decode64(a.data)).to eq(raw)
+  end
+
+  it "writes an error row when file exceeds the per-asset cap" do
+    raw = "x" * 30_000
+    File.write(File.join(@box, "wave.vcd"), raw)
+
+    described_class.new(box_path: @box, submission: submission, declarations: [declaration(max_size: 20480)]).call
+
+    a = submission.submission_assets.first
+    expect(a.data).to be_nil
+    expect(a.size_bytes).to eq(30_000)
+    expect(a.error).to eq("size_limit_exceeded")
+    expect(a.error_detail).to include("30000").and include("20480")
+  end
+
+  it "clamps a language max_size that exceeds MAX_MAX_ASSET_SIZE" do
+    raw = "x" * 30_000
+    File.write(File.join(@box, "wave.vcd"), raw)
+
+    stub_const("Config::MAX_MAX_ASSET_SIZE", 20480)
+    described_class.new(box_path: @box, submission: submission, declarations: [declaration(max_size: 1_000_000)]).call
+
+    a = submission.submission_assets.first
+    expect(a.error).to eq("size_limit_exceeded")
+    expect(a.error_detail).to include("20480") # ceiling, not 1_000_000
+  end
+
+  it "uses MAX_MAX_ASSET_SIZE when declaration omits max_size" do
+    raw = "x" * 100
+    File.write(File.join(@box, "wave.vcd"), raw)
+
+    stub_const("Config::MAX_MAX_ASSET_SIZE", 20480)
+    described_class.new(
+      box_path: @box,
+      submission: submission,
+      declarations: [{ name: "wave.vcd", identification: '\.vcd$' }]
+    ).call
+
+    a = submission.submission_assets.first
+    expect(a.error).to be_nil
+    expect(a.size_bytes).to eq(100)
+  end
+
+  it "picks first match alphabetically when regex matches multiple files" do
+    File.write(File.join(@box, "z.vcd"), "z")
+    File.write(File.join(@box, "a.vcd"), "a")
+    File.write(File.join(@box, "m.vcd"), "m")
+
+    described_class.new(box_path: @box, submission: submission, declarations: [declaration]).call
+
+    a = submission.submission_assets.first
+    expect(a.source_filename).to eq("a.vcd")
+    expect(Base64.decode64(a.data)).to eq("a")
+  end
+
+  it "skips an asset declaration with invalid regex without raising" do
+    File.write(File.join(@box, "wave.vcd"), "x")
+
+    described_class.new(
+      box_path: @box,
+      submission: submission,
+      declarations: [{ name: "wave.vcd", identification: "[broken" }]
+    ).call
+
+    expect(submission.submission_assets.count).to eq(0)
+  end
+end
+```
+
+- [ ] **Step 8.2: Run tests, verify they fail**
+
+```bash
+docker compose -f docker-compose.dev.yml exec judge0 bash -c 'cd /api && bundle exec rspec spec/services/asset_capture_spec.rb'
+```
+Expected: NameError or LoadError on `AssetCapture` because the service doesn't exist yet.
+
+- [ ] **Step 8.3: Implement the service**
+
+`app/services/asset_capture.rb`:
+```ruby
+require "base64"
+
+# Captures language-declared artifacts from the isolate box and persists
+# them as SubmissionAsset rows. Called by IsolateJob after run_cmd
+# completes, before `isolate --cleanup` wipes the box.
+#
+# Per spec docs/superpowers/specs/2026-05-05-submission-assets-design.md.
+class AssetCapture
+  def initialize(box_path:, submission:, declarations:)
+    @box_path     = box_path
+    @submission   = submission
+    @declarations = Array(declarations)
+  end
+
+  def call
+    @declarations.each { |d| capture_one(d) }
+  end
+
+  private
+
+  def capture_one(decl)
+    pattern = build_pattern(decl[:identification])
+    return if pattern.nil?  # invalid regex — skip silently
+
+    matched = Dir.entries(@box_path).select { |f| pattern.match?(f) }.sort.first
+    return if matched.nil?  # no match — no row written
+
+    file_path     = File.join(@box_path, matched)
+    raw_size      = File.size(file_path)
+    effective_cap = compute_cap(decl[:max_size])
+
+    if raw_size > effective_cap
+      @submission.submission_assets.create!(
+        logical_name:    decl[:name],
+        source_filename: matched,
+        size_bytes:      raw_size,
+        error:           "size_limit_exceeded",
+        error_detail:    "#{raw_size} bytes exceeds #{effective_cap} byte cap"
+      )
+    else
+      begin
+        bytes = File.binread(file_path)
+        @submission.submission_assets.create!(
+          logical_name:    decl[:name],
+          source_filename: matched,
+          size_bytes:      bytes.bytesize,
+          data:            Base64.strict_encode64(bytes)
+        )
+      rescue SystemCallError => e
+        @submission.submission_assets.create!(
+          logical_name:    decl[:name],
+          source_filename: matched,
+          size_bytes:      0,
+          error:           "read_error",
+          error_detail:    e.message
+        )
+      end
+    end
+  end
+
+  def build_pattern(identification)
+    Regexp.new(identification.to_s)
+  rescue RegexpError
+    nil
+  end
+
+  def compute_cap(declared)
+    ceiling = Config::MAX_MAX_ASSET_SIZE
+    [declared || ceiling, ceiling].min
+  end
+end
+```
+
+- [ ] **Step 8.4: Run tests, verify all pass**
+
+```bash
+docker compose -f docker-compose.dev.yml exec judge0 bash -c 'cd /api && bundle exec rspec spec/services/asset_capture_spec.rb'
+```
+Expected: 7 examples, 0 failures.
+
+- [ ] **Step 8.5: Commit**
+
+```bash
+git add app/services/asset_capture.rb spec/services/asset_capture_spec.rb
+git commit -m "Add AssetCapture service for box artifact persistence"
+```
+
+---
+
+## Task 9: Wire `AssetCapture` into `IsolateJob`
+
+**Files:**
+- Modify: `app/jobs/isolate_job.rb`
+
+- [ ] **Step 9.1: Locate the hook point**
+
+Open `app/jobs/isolate_job.rb`. The `perform` method runs `compile`, `reset_cgroup_for_run`, `run`, `verify`, then `cleanup` — `cleanup` runs `isolate --cleanup` and the box gets wiped. We hook *between `verify` and `cleanup`*. Around line ~37 in the run loop:
+
+```ruby
+      reset_cgroup_for_run
+      run
+      verify
+
+      time << submission.time
+      memory << submission.memory
+
+      cleanup        # ← we add a call to capture_assets immediately before this
+      break if submission.status != Status.ac
+```
+
+- [ ] **Step 9.2: Add the capture call**
+
+Replace the relevant block in `perform`:
+
+```ruby
+      reset_cgroup_for_run
+      run
+      verify
+
+      time << submission.time
+      memory << submission.memory
+
+      capture_assets
+      cleanup
+      break if submission.status != Status.ac
+```
+
+Also: add the `capture_assets` private method at the bottom of the file (alongside other privates like `cleanup`):
+
+```ruby
+  def capture_assets
+    return if submission.skip_assets
+    return if submission.language.assets.blank?
+
+    AssetCapture.new(
+      box_path:     boxdir,
+      submission:   submission,
+      declarations: submission.language.assets
+    ).call
+  rescue StandardError => e
+    # Capture failure must not break the submission. Log and move on;
+    # cleanup will run regardless.
+    Rails.logger.error("AssetCapture failed for submission #{submission.id}: #{e.class} #{e.message}")
+  end
+```
+
+The early-return guards mirror the spec's two-level decision (caller opt-out + language opt-in). The `rescue` ensures a problem in capture never breaks grading.
+
+- [ ] **Step 9.3: Sanity-check it parses**
+
+```bash
+docker compose -f docker-compose.dev.yml exec judge0 bash -c 'cd /api && ruby -c app/jobs/isolate_job.rb'
+```
+Expected: `Syntax OK`.
+
+- [ ] **Step 9.4: Commit**
+
+```bash
+git add app/jobs/isolate_job.rb
+git commit -m "IsolateJob: capture declared assets before cleanup"
+```
+
+---
+
+## Task 10: Expose `assets` field via `Submission#language` accessor
+
+The `Language` model's `assets` is a Postgres `text` column today storing the `assets:` array as YAML/JSON in seeds.rb (or it doesn't exist yet, depending on how `active.rb` is loaded into the DB). Investigate.
+
+**Files:**
+- Modify: `db/seeds.rb` (if `assets` is not yet persisted)
+- Modify: `app/models/language.rb` (if necessary)
+
+- [ ] **Step 10.1: Determine current Language schema**
+
+```bash
+docker compose -f docker-compose.dev.yml exec db psql -U judge0 -d judge0 -c '\d languages'
+```
+Note whether an `assets` column exists.
+
+- [ ] **Step 10.2: If `assets` does NOT exist, add a migration**
+
+Create `db/migrate/20260505000003_add_assets_to_languages.rb`:
+```ruby
+class AddAssetsToLanguages < ActiveRecord::Migration[5.2]
+  def change
+    add_column :languages, :assets, :text  # serialized YAML
+  end
+end
+```
+
+Run: `rake db:migrate` inside the container. Then in `app/models/language.rb`, add:
+```ruby
+  serialize :assets
+```
+
+If the column already exists, skip the migration and confirm `serialize :assets` is present.
+
+- [ ] **Step 10.3: Update `db/seeds.rb` to persist `assets`**
+
+In `db/seeds.rb`, find the loop where Language records are created/updated. The existing code likely does something like `Language.find_or_create_by(id: lang[:id]).update(name: lang[:name], ...)`. Add `assets: lang[:assets]` to the update hash so `Language#assets` reflects the active.rb declaration:
+
+```ruby
+Language.find_or_create_by(id: lang[:id]).update(
+  name:         lang[:name],
+  is_archived:  lang[:is_archived],
+  source_file:  lang[:source_file],
+  compile_cmd:  lang[:compile_cmd],
+  run_cmd:      lang[:run_cmd],
+  assets:       lang[:assets]   # nil for languages that don't declare any
+)
+```
+
+(Match the existing seed pattern; the relevant fields will already be there. Just add `assets:`.)
+
+- [ ] **Step 10.4: Re-seed and verify**
+
+```bash
+docker compose -f docker-compose.dev.yml exec judge0 bash -c 'cd /api && rake db:seed'
+docker compose -f docker-compose.dev.yml exec judge0 bash -c 'cd /api && rails runner "puts Language.find(46).assets.inspect"'
+```
+Expected: `nil` (Bash 46 has no assets declared yet).
+
+- [ ] **Step 10.5: Commit**
+
+```bash
+git add db/seeds.rb app/models/language.rb db/migrate/20260505000003_add_assets_to_languages.rb db/schema.rb
+git commit -m "Persist Language#assets from active.rb"
+```
+
+---
+
+## Task 11: Declare `assets:` for Verilog 3005
+
+**Files:**
+- Modify: `db/languages/active.rb`
+
+- [ ] **Step 11.1: Add the assets field**
+
+In `db/languages/active.rb`, find the Verilog 3005 entry and add `assets:` after `run_cmd`:
+
+```ruby
+  {
+    id: 3005,
+    name: "Verilog (Icarus 13.0)",
+    is_archived: false,
+    source_file: "main.v",
+    compile_cmd: "/usr/local/iverilog-13.0/bin/iverilog -g2012 -tnull %s main.v",
+    run_cmd: "/bin/cat > tb.v && /usr/local/iverilog-13.0/bin/iverilog -g2012 -o sim.vvp main.v tb.v && /usr/local/iverilog-13.0/bin/vvp sim.vvp",
+    assets: [
+      { name: "wave.vcd", identification: '\.vcd$', max_size: 20480 }
+    ]
+  }
+```
+
+- [ ] **Step 11.2: Run the lint to confirm**
+
+```bash
+docker compose -f docker-compose.dev.yml exec judge0 bash -c 'cd /api && ruby bin/lint-active-rb'
+```
+Expected: `OK — 21 languages, 1 asset declarations validated.`
+
+- [ ] **Step 11.3: Re-seed**
+
+```bash
+docker compose -f docker-compose.dev.yml exec judge0 bash -c 'cd /api && rake db:seed'
+docker compose -f docker-compose.dev.yml exec judge0 bash -c 'cd /api && rails runner "puts Language.find(3005).assets.inspect"'
+```
+Expected: `[{:name=>"wave.vcd", :identification=>"\\.vcd$", :max_size=>20480}]`.
+
+- [ ] **Step 11.4: Commit**
+
+```bash
+git add db/languages/active.rb
+git commit -m "Declare wave.vcd asset for Verilog 3005"
+```
+
+---
+
+## Task 12: Accept `skip_assets` in submission POST body
+
+**Files:**
+- Modify: `app/controllers/submissions_controller.rb`
+
+- [ ] **Step 12.1: Locate the parameter list**
+
+In `app/controllers/submissions_controller.rb`, find `submission_params` (private method that calls `params.permit(...)`).
+
+- [ ] **Step 12.2: Add `:skip_assets` to permitted params**
+
+Add `:skip_assets` to the list of permitted attributes:
+```ruby
+  def submission_params
+    params.permit(:source_code, :language_id, :additional_files,
+                  :compiler_options, :command_line_arguments,
+                  :stdin, :expected_output, :cpu_time_limit,
+                  # ... existing list ...
+                  :skip_assets)
+  end
+```
+
+(Match the existing structure; add `:skip_assets` to whatever list is already there.)
+
+- [ ] **Step 12.3: Manual smoke check via curl**
+
+After restarting the judge0 service:
+```bash
+curl -s -X POST 'http://localhost:2358/submissions?wait=false&fields=token' \
+  -H 'Content-Type: application/json' \
+  -d '{"language_id": 46, "source_code": "echo hi", "skip_assets": true}' | jq .
+```
+Expected: `{ "token": "..." }`. Then check the persisted value:
+```bash
+docker compose -f docker-compose.dev.yml exec judge0 bash -c 'cd /api && rails runner "puts Submission.last.skip_assets.inspect"'
+```
+Expected: `true`.
+
+- [ ] **Step 12.4: Commit**
+
+```bash
+git add app/controllers/submissions_controller.rb
+git commit -m "Accept skip_assets in submission POST body"
+```
+
+---
+
+## Task 13: `SubmissionAssetSerializer` + assets field on submission JSON
+
+**Files:**
+- Create: `app/serializers/submission_asset_serializer.rb`
+- Modify: `app/serializers/submission_serializer.rb`
+
+- [ ] **Step 13.1: Write the asset serializer (metadata only — no data)**
+
+`app/serializers/submission_asset_serializer.rb`:
+```ruby
+class SubmissionAssetSerializer < ActiveModel::Serializer
+  attributes :logical_name, :source_filename, :size_bytes, :error, :error_detail
+end
+```
+
+- [ ] **Step 13.2: Add `assets` to the submission serializer**
+
+In `app/serializers/submission_serializer.rb`, after the existing `attributes` line and method definitions, add:
+
+```ruby
+  attribute :assets
+
+  def assets
+    object.submission_assets.map { |a| SubmissionAssetSerializer.new(a).attributes }
+  end
+```
+
+This returns an array of metadata hashes — no `data`. The bytes endpoint (Task 14) is the only way to fetch the `data`.
+
+- [ ] **Step 13.3: Manual smoke**
+
+Submit a Bash hello-world (no assets declared for Bash) and request `assets`:
+```bash
+TOKEN=$(curl -s -X POST 'http://localhost:2358/submissions?wait=true&fields=token' \
+  -H 'Content-Type: application/json' \
+  -d '{"language_id": 46, "source_code": "echo hi"}' | jq -r .token)
+curl -s "http://localhost:2358/submissions/$TOKEN?fields=token,assets" | jq .
+```
+Expected: `{ "token": "...", "assets": [] }`.
+
+- [ ] **Step 13.4: Commit**
+
+```bash
+git add app/serializers/submission_asset_serializer.rb app/serializers/submission_serializer.rb
+git commit -m "Expose submission assets metadata via SubmissionSerializer"
+```
+
+---
+
+## Task 14: Asset bytes endpoint
+
+**Files:**
+- Create: `app/controllers/submission_assets_controller.rb`
+- Modify: `config/routes.rb`
+
+- [ ] **Step 14.1: Write the controller**
+
+`app/controllers/submission_assets_controller.rb`:
+```ruby
+require "base64"
+
+class SubmissionAssetsController < ApplicationController
+  before_action :set_submission_and_asset
+
+  # GET /submissions/:submission_token/assets/:logical_name
+  # Default response: { "data": "<base64>" } JSON.
+  # When Accept: application/octet-stream, ships decoded bytes.
+  def show
+    if @asset.data.nil?
+      head :not_found
+      return
+    end
+
+    if request.format.symbol == :octet_stream || request.headers["Accept"] == "application/octet-stream"
+      send_data Base64.decode64(@asset.data),
+                type: "application/octet-stream",
+                disposition: "attachment",
+                filename: (@asset.source_filename.presence || @asset.logical_name)
+    else
+      render json: { data: @asset.data }
+    end
+  end
+
+  private
+
+  def set_submission_and_asset
+    submission = Submission.find_by!(token: params[:submission_token])
+    @asset     = submission.submission_assets.find_by!(logical_name: params[:logical_name])
+  rescue ActiveRecord::RecordNotFound
+    head :not_found
+  end
+end
+```
+
+- [ ] **Step 14.2: Add the nested route**
+
+In `config/routes.rb`, change the existing submissions resource to add a member route:
+
+```ruby
+  resources :submissions, only: [:index, :show, :create, :destroy], param: :token do
+    post 'batch', to: 'submissions#batch_create', on: :collection
+    get 'batch', to: 'submissions#batch_show', on: :collection
+
+    get 'assets/:logical_name',
+        to: 'submission_assets#show',
+        constraints: { logical_name: /[^\/]+/ },
+        as: :asset
+  end
+```
+
+The `constraints: { logical_name: /[^\/]+/ }` allows dots and other characters in filenames (e.g., `wave.vcd`).
+
+- [ ] **Step 14.3: Verify routes**
+
+```bash
+docker compose -f docker-compose.dev.yml exec judge0 bash -c 'cd /api && rails routes | grep submission_asset'
+```
+Expected: a route mapping `GET /submissions/:submission_token/assets/:logical_name` to `submission_assets#show`.
+
+- [ ] **Step 14.4: Manual smoke (no asset present yet)**
+
+```bash
+TOKEN=$(curl -s -X POST 'http://localhost:2358/submissions?wait=true&fields=token' \
+  -H 'Content-Type: application/json' \
+  -d '{"language_id": 46, "source_code": "echo hi"}' | jq -r .token)
+curl -s -o /dev/null -w '%{http_code}\n' "http://localhost:2358/submissions/$TOKEN/assets/wave.vcd"
+```
+Expected: `404` (no asset row exists for the bash submission).
+
+- [ ] **Step 14.5: Commit**
+
+```bash
+git add app/controllers/submission_assets_controller.rb config/routes.rb
+git commit -m "Add asset bytes endpoint"
+```
+
+---
+
+## Task 15: End-to-end Verilog asset test
+
+Submit a Verilog DUT + testbench-with-`$dumpfile` via the API, fetch the resulting submission with `fields=...,assets`, and verify the asset metadata + bytes endpoint.
+
+**Files:**
+- Modify: `bin/newton-smoke-test`
+
+- [ ] **Step 15.1: Add a new test snippet for Verilog with waveform**
+
+In `bin/newton-smoke-test`, add a new section after the existing Verilog cases. First the source snippets:
+
+```bash
+SRC_VERILOG_WAVE='module and_gate(input wire a, input wire b, output wire y);
+  assign y = a & b;
+endmodule'
+
+STDIN_VERILOG_WAVE='`timescale 1ns/1ps
+module and_gate_tb;
+  reg a; reg b; wire y;
+  and_gate uut (.a(a), .b(b), .y(y));
+  initial begin
+    $dumpfile("wave.vcd");
+    $dumpvars(0, and_gate_tb);
+    a = 0; b = 0; #10;
+    a = 0; b = 1; #10;
+    a = 1; b = 0; #10;
+    a = 1; b = 1; #10;
+    $display("Hello, Newton!");
+    $finish(0);
+  end
+endmodule'
+```
+
+- [ ] **Step 15.2: Add a new helper `t_stdin_with_asset` that asserts asset metadata**
+
+In `bin/newton-smoke-test` (alongside the existing `t_stdin`), add:
+
+```bash
+# t_stdin_with_asset <name> <language_id> <source_code> <stdin> <expected_substring> <asset_logical_name>
+# Same as t_stdin but additionally fetches submission with fields=...,assets,
+# checks the named asset is present with size_bytes > 0 and error == null,
+# and confirms GET /submissions/:token/assets/:logical_name returns 200 with non-empty body.
+t_stdin_with_asset() {
+    local name="$1" lid="$2" src="$3" stdin="$4" expected="$5" asset_name="$6"
+    local payload resp token assets_json size err
+
+    payload="$(jq -nc --arg sc "$src" --arg si "$stdin" --argjson lid "$lid" \
+        '{language_id:$lid, source_code:$sc, stdin:$si}')"
+    resp="$(curl -s -X POST "${URL}/submissions?wait=true&fields=token,stdout,stderr,status,message,compile_output,assets" \
+        -H 'Content-Type: application/json' -d "$payload")"
+
+    token="$(echo "$resp" | jq -r '.token // empty')"
+    _check_resp "$name" "$lid" "$expected" "$resp"
+
+    if [[ -z "$token" ]]; then
+        printf "  \033[31mFAIL\033[0m  %s asset check skipped (no token)\n" "$name"
+        FAIL=$((FAIL+1))
+        FAILED+=("$name asset (no token)")
+        return
+    fi
+
+    assets_json="$(echo "$resp" | jq -c --arg n "$asset_name" '.assets // [] | map(select(.logical_name == $n)) | .[0] // {}')"
+    size="$(echo "$assets_json" | jq -r '.size_bytes // 0')"
+    err="$(echo "$assets_json" | jq -r '.error // empty')"
+
+    if [[ -n "$err" || "$size" -le 0 ]]; then
+        printf "  \033[31mFAIL\033[0m  %s asset check  size=%s err=%s\n" "$name" "$size" "$err"
+        FAIL=$((FAIL+1))
+        FAILED+=("$name asset (size=$size, err=$err)")
+        return
+    fi
+
+    local bytes_status
+    bytes_status="$(curl -s -o /dev/null -w '%{http_code}' "${URL}/submissions/$token/assets/$asset_name")"
+    if [[ "$bytes_status" != "200" ]]; then
+        printf "  \033[31mFAIL\033[0m  %s asset bytes endpoint http=%s\n" "$name" "$bytes_status"
+        FAIL=$((FAIL+1))
+        FAILED+=("$name asset bytes (http $bytes_status)")
+        return
+    fi
+
+    printf "  \033[32mPASS\033[0m  %s asset (size=%s)\n" "$name" "$size"
+    PASS=$((PASS+1))
+}
+```
+
+- [ ] **Step 15.3: Call the helper for the Verilog wave case**
+
+In the Newton extras section of `bin/newton-smoke-test` (after the existing Verilog calls), add:
+
+```bash
+# Verilog with waveform: testbench includes $dumpfile + $dumpvars; we
+# expect a wave.vcd asset to be captured and surfaced via the API.
+t_stdin_with_asset "Verilog 3005 with wave.vcd asset" 3005 \
+    "$SRC_VERILOG_WAVE" "$STDIN_VERILOG_WAVE" "$EXPECTED" "wave.vcd"
+```
+
+- [ ] **Step 15.4: Run the smoke test against local dev**
+
+```bash
+JUDGE0_URL=http://localhost:2358 ./bin/newton-smoke-test
+```
+Expected count: previously 23/0/0; now 24/0/0 on amd64 (one new PASS for the asset case). On arm64, was 21/0/2; now 22/0/2.
+
+- [ ] **Step 15.5: Commit**
+
+```bash
+git add bin/newton-smoke-test
+git commit -m "Smoke test: verify Verilog 3005 captures wave.vcd asset end-to-end"
+```
+
+---
+
+## Task 16: Update CLAUDE.md
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 16.1: Update smoke counts**
+
+In the "End-to-end smoke test" section, change "23 PASS / 0 FAIL / 0 SKIP on amd64; 21 PASS / 0 FAIL / 2 SKIP on arm64" to:
+
+```
+**24 PASS / 0 FAIL / 0 SKIP** on amd64; **22 PASS / 0 FAIL / 2 SKIP** on
+arm64 (NASM and FreeBASIC are amd64-only upstream).
+```
+
+- [ ] **Step 16.2: Add `MAX_MAX_ASSET_SIZE` to the judge0.conf knobs table**
+
+In the "judge0.conf knobs" table, append a row:
+
+```
+| `MAX_MAX_ASSET_SIZE` | – (new in 0.67) | **20480** (20 KB) | per-asset cap; clamps language declarations |
+```
+
+- [ ] **Step 16.3: Add a Per-language tuning note**
+
+In "Per-language tuning conventions", append a bullet after the existing Verilog 3005 note:
+
+```
+- **Submission assets (Phase 3 / 0.67+).** Languages may declare an
+  `assets:` array in `active.rb` (e.g., Verilog 3005 declares
+  `wave.vcd`). After `run_cmd` exits, `IsolateJob` calls
+  `AssetCapture` to glob the box for matching files and persist them
+  as `submission_assets` rows (base64 in a `text` column, capped per
+  declaration / `MAX_MAX_ASSET_SIZE`). API exposure: extended submission
+  GET (metadata via `fields=...,assets`) + dedicated bytes endpoint
+  `GET /submissions/:token/assets/:logical_name`. Per-submission
+  opt-out via `skip_assets: true` in the POST body. See
+  `docs/superpowers/specs/2026-05-05-submission-assets-design.md`.
+```
+
+- [ ] **Step 16.4: Bump the published-tag note**
+
+In "Image is published as", change `Current tag: **0.66**` to:
+
+```
+- Current tag: **`0.67`** — adds Phase 3 submission-assets capture
+  (Verilog 3005 declares `wave.vcd`; framework is language-agnostic).
+  Smoke target 24/0/0 on amd64.
+```
+
+Update the chronology range from `0.53 → 0.66` to `0.53 → 0.67`.
+
+- [ ] **Step 16.5: Bump the AL2-prereq line**
+
+In the same section, the existing line `**Before bumping prod to 0.66:** prod nodes still run Amazon Linux 2 (cgroup v1).` becomes:
+
+```
+- **Before bumping prod to 0.67:** prod nodes still run Amazon Linux 2 (cgroup v1).
+```
+
+- [ ] **Step 16.6: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "Document Phase 3 submission assets in CLAUDE.md"
+```
+
+---
+
+## Task 17: Bump version refs in compose + Postman
+
+**Files:**
+- Modify: `docker-compose.dev.yml`
+- Modify: `bin/newton-postman.json`
+
+- [ ] **Step 17.1: Bump compose tag**
+
+In `docker-compose.dev.yml`, change `:0.66` → `:0.67` on the `judge0` service `image:` line and in the build-command comment above it.
+
+- [ ] **Step 17.2: Bump postman collection name**
+
+In `bin/newton-postman.json`, change `"Newton Judge0 — All Languages (0.66)"` to `"Newton Judge0 — All Languages (0.67)"`.
+
+- [ ] **Step 17.3: Commit**
+
+```bash
+git add docker-compose.dev.yml bin/newton-postman.json
+git commit -m "Bump tag refs 0.66 → 0.67"
+```
+
+---
+
+## Task 18: Build, smoke locally, push staging
+
+**Files:** none — this is a deploy gate.
+
+- [ ] **Step 18.1: arm64 dev build (Mac)**
+
+```bash
+docker buildx build --platform linux/arm64 \
+  -f NewtonDockerfile \
+  -t newtonschool/newton-judge0:0.67 \
+  --load .
+```
+
+Expected: build completes, ~15–20 min from scratch.
+
+- [ ] **Step 18.2: Bring up dev stack with the new image**
+
+```bash
+docker compose -f docker-compose.dev.yml down -v
+docker compose -f docker-compose.dev.yml up -d judge0 db redis redis-sidecar
+docker compose -f docker-compose.dev.yml exec -d --privileged judge0 \
+  bash -c 'source /api/scripts/load-config; cd /api && rake resque:workers QUEUE=*'
+sleep 20
+```
+
+- [ ] **Step 18.3: arm64 smoke**
+
+```bash
+JUDGE0_URL=http://localhost:2358 ./bin/newton-smoke-test
+```
+Expected: **22 PASS / 0 FAIL / 2 SKIP** (arm64). Includes the new asset case.
+
+- [ ] **Step 18.4: amd64 EC2 build (in tmux)**
+
+On EC2:
+```bash
+git pull origin <branch>
+docker buildx build --platform linux/amd64 \
+  -f NewtonDockerfile \
+  -t newtonschool/newton-judge0:0.67 \
+  --load .
+```
+Then bring up the same stack and run the smoke. Expected: **24 PASS / 0 FAIL / 0 SKIP**.
+
+- [ ] **Step 18.5: Push to Docker Hub**
+
+```bash
+docker push newtonschool/newton-judge0:0.67
+```
+
+- [ ] **Step 18.6: Deploy to staging and smoke against it**
+
+Use whatever the existing staging deploy mechanism is (kubectl / ECR push). Then:
+```bash
+JUDGE0_URL=https://judge0-public.staging-newtonschool.co ./bin/newton-smoke-test
+```
+Expected: **24/0/0** on the staging amd64 cluster.
+
+---
+
+## Self-review
+
+**Spec coverage:**
+- ✅ `submission_assets` table schema (Task 1)
+- ✅ `submissions.skip_assets` column (Task 2)
+- ✅ `MAX_MAX_ASSET_SIZE` config (Task 3)
+- ✅ Model + association (Task 4)
+- ✅ AssetValidator + tests (Task 5)
+- ✅ Seed-time validation (Task 6)
+- ✅ `bin/lint-active-rb` CLI (Task 7)
+- ✅ AssetCapture service + tests (Task 8)
+- ✅ IsolateJob hook with two-level decision (Task 9)
+- ✅ Language#assets column persistence (Task 10)
+- ✅ Verilog 3005 asset declaration (Task 11)
+- ✅ `skip_assets` in POST body (Task 12)
+- ✅ Submission/Asset serializers (Task 13)
+- ✅ Bytes endpoint + route (Task 14)
+- ✅ End-to-end smoke (Task 15)
+- ✅ CLAUDE.md docs (Task 16)
+- ✅ Tag bumps (Task 17)
+- ✅ Build + smoke + push (Task 18)
+
+**Placeholder scan:** No "TBD" / "TODO" / "implement later". Every code step has full code; every test step has full test code.
+
+**Type consistency:**
+- `AssetCapture` initializer keyword args: `box_path`, `submission`, `declarations` — used identically in the service implementation, the spec, and IsolateJob.
+- `SubmissionAsset` columns: `logical_name`, `source_filename`, `data`, `size_bytes`, `error`, `error_detail` — identical across migration, model, serializer, and AssetCapture.
+- `Config::MAX_MAX_ASSET_SIZE` — same name in `Config` constant, `judge0.conf` env var, and AssetCapture reference.
+- `skip_assets` — same name as boolean column, model attribute, and POST param.
+- Asset declaration field names: `name`, `identification`, `max_size` — same in spec, validator, capture service, and active.rb.
+
+---
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-05-submission-assets.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+
+**2. Inline Execution** — Execute tasks in this session using `executing-plans`, batch execution with checkpoints.
+
+Which approach?

--- a/docs/superpowers/specs/2026-05-05-submission-assets-design.md
+++ b/docs/superpowers/specs/2026-05-05-submission-assets-design.md
@@ -1,0 +1,548 @@
+# Submission asset capture — design
+
+**Date:** 2026-05-05
+**Author:** gkapatia (with Claude)
+**Repos touched:** `Newton-School/judge0`
+**Target tag:** `newton-judge0:0.67`
+**Phase 3 of the Verilog integration work** (see
+`2026-05-02-iverilog-integration-design.md` for Phases 1–2).
+
+## Goal
+
+Capture binary/text artifacts produced inside the isolate sandbox during
+a submission run (Verilog `.vcd` waveforms first, but the mechanism is
+language-agnostic) and surface them via the judge0 API alongside
+`stdout`/`stderr`/`status`. Today these files are wiped on
+`isolate --cleanup` and never reach the caller.
+
+The first concrete use case is Verilog: students need to see waveforms
+to debug their DUT logic, and the testbench already produces a `.vcd`
+file when it calls `$dumpfile` / `$dumpvars`. judge0 just needs to read
+that file out of the box before cleanup, persist it, and expose it via
+the API. Future use cases (C++ core dumps, JVM heap dumps, Python
+`cProfile` traces, etc.) will reuse the same mechanism.
+
+## Why this design and not stdout markers
+
+An earlier draft proposed encoding the artifact as base64 in `stdout`
+between markers (`===WAVE===` / `===END===`). That was rejected because
+the platform's grader compares `stdout` against `expected_output`
+byte-for-byte — any marker block in `stdout` would either break
+grading or force every consumer (CLI, mobile, future clients) to learn
+how to split the marker out before comparing.
+
+A `stderr` variant (writing the marker block to stderr instead) was
+considered as a smaller-effort alternative. It works mechanically, but
+muddies stderr semantics (warnings + errors + base64 payload all in
+one stream) and still requires every client to know the marker
+convention. For v1 of a feature that's expected to grow (multiple
+asset types per language, per-asset metadata, possibly per-asset
+download endpoints), the cleaner separation of a dedicated DB-backed
+mechanism wins.
+
+## High-level model
+
+A language definition in `db/languages/active.rb` may declare an
+`assets` array. Each entry tells `IsolateJob` which file pattern to
+look for in the box after `run_cmd` finishes and what to label the
+captured file as:
+
+```ruby
+{
+  id: 3005,
+  name: "Verilog (Icarus 13.0)",
+  ...
+  run_cmd: "/bin/cat > tb.v && ... && /usr/local/iverilog-13.0/bin/vvp sim.vvp",
+  assets: [
+    { name: "wave.vcd", identification: '\.vcd$', max_size: 20480 }
+  ]
+}
+```
+
+After `run_cmd` exits, `IsolateJob` walks the language's `assets`,
+scans the box for files matching each `identification` regex, and
+writes one `SubmissionAsset` row per matched file (capped at
+`max_size` bytes). Rows persist as long as the parent submission does.
+The API surfaces each asset's metadata in the submission JSON and
+exposes the bytes via a dedicated endpoint.
+
+Author opt-in is implicit: a testbench that doesn't call `$dumpfile`
+produces no `.vcd`, the regex matches nothing, and no row is written.
+Languages without an `assets:` array get no capture step at all.
+
+## Schema
+
+### `submission_assets` table
+
+```ruby
+class CreateSubmissionAssets < ActiveRecord::Migration[5.2]
+  def change
+    create_table :submission_assets do |t|
+      t.references :submission,
+                   foreign_key: { on_delete: :cascade },
+                   null: false
+      t.string :logical_name,    null: false   # "wave.vcd" from active.rb
+      t.string :source_filename                 # actual matched filename
+      t.text :data                              # base64-encoded, null when error set
+      t.integer :size_bytes,     null: false   # raw byte size, even when error
+      t.string :error                           # "size_limit_exceeded" | "read_error" | nil
+      t.text :error_detail                      # human-readable detail
+      t.timestamps
+    end
+
+    add_index :submission_assets, [:submission_id, :logical_name]
+  end
+end
+```
+
+Notes:
+
+- **`text` column storing base64.** Keeps the data JSON-safe out of
+  the box (no on-the-way-out encoding step), greppable in `psql` for
+  debugging, and easy to migrate or dump-restore. Costs ~33% storage
+  inflation vs raw bytes — at the volumes we expect (~10s of GB/year)
+  not a concern.
+- **`size_bytes` always reports the *raw* file size**, not the base64
+  string size. This is what the cap is checked against and what the
+  UI renders ("produced 55340 bytes — exceeded 20480 byte cap").
+- **`logical_name` vs `source_filename`.** Logical name comes from the
+  `assets:` declaration ("wave.vcd") and is the stable contract the
+  platform UI keys off. Source filename is the actual matched file
+  ("wave.vcd" or "custom.vcd" if the author called
+  `$dumpfile("custom.vcd")`) — useful for download UX and debugging.
+- **Composite index on `(submission_id, logical_name)`** supports the
+  "give me asset X for submission Y" query path which is the dominant
+  read pattern.
+- **Cascade delete.** When a submission is pruned (judge0's existing
+  cleanup), its assets go with it.
+
+### `submissions.skip_assets` column
+
+```ruby
+class AddSkipAssetsToSubmissions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :submissions, :skip_assets, :boolean,
+                                            default: false,
+                                            null: false
+  end
+end
+```
+
+Persisted on the submission record (rather than passed through as a
+job arg) so there's an audit trail of which submissions opted out and
+the worker can read it directly off the submission row.
+
+## `active.rb` schema additions
+
+Each language entry may include an `assets:` array. Each asset
+declaration is a hash with these fields:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | String | yes | Logical label stored on the row. Stable contract for clients. |
+| `identification` | String (regex) | yes | Ruby regex matched against filenames in the box. Use single-quoted strings to avoid double-escape: `'\.vcd$'`. No implicit anchoring — author writes `^`/`$` if they want. |
+| `max_size` | Integer (bytes) | no | Per-asset cap. Falls back to `MAX_MAX_ASSET_SIZE` when omitted. Clamped to `MAX_MAX_ASSET_SIZE` if it exceeds the global ceiling. |
+
+Concrete Verilog 3005 entry after this spec lands:
+
+```ruby
+{
+  id: 3005,
+  name: "Verilog (Icarus 13.0)",
+  is_archived: false,
+  source_file: "main.v",
+  compile_cmd: "/usr/local/iverilog-13.0/bin/iverilog -g2012 -tnull %s main.v",
+  run_cmd: "/bin/cat > tb.v && /usr/local/iverilog-13.0/bin/iverilog -g2012 -o sim.vvp main.v tb.v && /usr/local/iverilog-13.0/bin/vvp sim.vvp",
+  assets: [
+    { name: "wave.vcd", identification: '\.vcd$', max_size: 20480 }
+  ]
+}
+```
+
+The `run_cmd` itself stays exactly as it is post-Phase-2 — no marker
+emission, no glob/encode logic in shell. All of that moves into Ruby.
+
+## Configuration knobs (`judge0.conf`)
+
+```
+# ---- Asset capture (Phase 3) ----
+
+# Hard ceiling on asset size in bytes. Acts as both:
+#   - the default cap when a language's `assets:` declaration omits
+#     `max_size`
+#   - the absolute clamp on any per-language `max_size` (a language
+#     cannot exceed this, only ask for less)
+# Mirrors the role of MAX_MAX_MEMORY_LIMIT / MAX_MAX_FILE_SIZE.
+MAX_MAX_ASSET_SIZE=20480
+```
+
+`Config::MAX_MAX_ASSET_SIZE` exposed as a Rails initializer read of
+this env var. Single global knob, no per-deployment "default vs hard
+ceiling" split — operationally simpler.
+
+There is intentionally **no global feature gate** (no
+`ENABLE_ASSETS`). Per-submission opt-out via `skip_assets` is the
+caller's lever; per-language opt-in via `assets:` declaration is the
+language designer's lever. If ops needs to effectively disable
+capture deployment-wide, set `MAX_MAX_ASSET_SIZE=0` — every file then
+exceeds the cap, so no `data` is stored (only error rows for
+matches), and storage stays bounded.
+
+## Capture rules
+
+### Two-level decision
+
+`IsolateJob#capture_assets` is called after `run_cmd` exits, before
+`isolate --cleanup`. It returns early in two cases:
+
+```ruby
+def capture_assets
+  return if @submission.skip_assets                                   # 1. caller opt-out
+  return if language.assets.blank?                                    # 2. language opt-in
+  ...
+end
+```
+
+- **Caller opt-out (`skip_assets`):** per-submission preference set in
+  the POST body. Useful for batch grading runs that don't need
+  artifacts.
+- **Language opt-in (`assets:` array):** implicit — a language without
+  any asset declarations contributes no capture work.
+
+There is no global ops gate. Asset capture is always available for
+languages that declare it; callers that don't want it for a specific
+submission set `skip_assets: true`. If ops needs an emergency clamp,
+`MAX_MAX_ASSET_SIZE=0` makes every file an over-cap error (no `data`
+stored).
+
+### Match resolution
+
+For each declared asset:
+
+```ruby
+pattern = Regexp.new(asset[:identification])
+matches = Dir.entries(box_path).select { |f| pattern.match?(f) }.sort
+matched_file = matches.first
+```
+
+- **Sorted alphabetically**, first match wins. Deterministic.
+- **No match** → no row written. The "no row" rule is intentional: a
+  problem that doesn't dump shouldn't get a per-asset row saying
+  "didn't happen". A row exists ⇔ a file was identified.
+- **Multiple matches.** For VCD this can't happen per IEEE 1364 (single
+  `$dumpfile` per simulation); for future asset types it might. First
+  alphabetically is safer than last-modified (less environment
+  dependence). Future extension: `multi: true` declaration field
+  to write a row per match.
+- **Invalid regex** → IsolateJob logs a warning, skips that asset,
+  submission still succeeds. Should never happen in practice because
+  the lint script and seed-time check (below) reject invalid regexes
+  before they reach a running container.
+
+### Size cap resolution
+
+```ruby
+declared      = asset[:max_size]
+hard_ceiling  = Config::MAX_MAX_ASSET_SIZE
+
+effective_cap = [declared || hard_ceiling, hard_ceiling].min
+```
+
+Three cases:
+
+| `asset[:max_size]` | Effective cap |
+|---|---|
+| nil (omitted) | `MAX_MAX_ASSET_SIZE` |
+| Set, `≤ MAX_MAX_ASSET_SIZE` | the declared value |
+| Set, `> MAX_MAX_ASSET_SIZE` | `MAX_MAX_ASSET_SIZE` (clamped) |
+
+A language can ask for a *smaller* cap than the global ceiling; it
+cannot ask for a larger one.
+
+### Outcome rows
+
+| State | Row written? | Fields populated |
+|---|---|---|
+| No file matches regex | no | — |
+| Match within cap, readable | yes | `data`, `size_bytes`, `source_filename`, `error = nil` |
+| Match exceeds cap | yes | `data = nil`, `size_bytes` = actual size, `source_filename`, `error = "size_limit_exceeded"`, `error_detail = "55340 bytes exceeds 20480 byte cap"` |
+| Match unreadable (I/O error) | yes | `data = nil`, `size_bytes = 0` (or known size if statable), `error = "read_error"`, `error_detail` = OS message |
+
+The error rows exist precisely so the platform UI can render
+"waveform produced (55 KB) — exceeded 20 KB display cap" rather than
+silently showing nothing.
+
+## Validation
+
+Asset declarations in `active.rb` are checked at two layers:
+
+### Layer 1 — seed-time check
+
+`db/seeds.rb` already loads `active.rb` and writes to the DB on every
+container startup. We add a validation pass before insert; bad data
+fails the seed → container won't start → bad config never reaches
+production.
+
+```ruby
+@languages.each do |lang|
+  Array(lang[:assets]).each do |asset|
+    raise "active.rb: language #{lang[:id]} asset missing :name" \
+      if asset[:name].to_s.empty?
+
+    raise "active.rb: language #{lang[:id]} asset #{asset[:name].inspect} missing :identification" \
+      if asset[:identification].to_s.empty?
+
+    begin
+      Regexp.new(asset[:identification])
+    rescue RegexpError => e
+      raise "active.rb: language #{lang[:id]} asset #{asset[:name].inspect} identification #{asset[:identification].inspect} not a valid regex: #{e.message}"
+    end
+
+    if asset.key?(:max_size)
+      raise "active.rb: language #{lang[:id]} asset #{asset[:name].inspect} max_size must be positive Integer (got #{asset[:max_size].inspect})" \
+        unless asset[:max_size].is_a?(Integer) && asset[:max_size] > 0
+    end
+  end
+end
+```
+
+### Layer 2 — CLI lint (CI / pre-commit)
+
+Standalone script that runs the same checks without touching the DB
+or Rails framework:
+
+```ruby
+#!/usr/bin/env ruby
+# bin/lint-active-rb — schema check for db/languages/active.rb
+
+require_relative '../db/languages/active'
+
+errors = []
+@languages.each do |lang|
+  Array(lang[:assets]).each_with_index do |asset, i|
+    prefix = "lang #{lang[:id]} (#{lang[:name].inspect}) asset[#{i}]"
+
+    errors << "#{prefix}: missing :name"           if asset[:name].to_s.empty?
+    errors << "#{prefix}: missing :identification" if asset[:identification].to_s.empty?
+
+    if asset[:identification]
+      begin
+        Regexp.new(asset[:identification])
+      rescue RegexpError => e
+        errors << "#{prefix}: identification #{asset[:identification].inspect} not valid regex — #{e.message}"
+      end
+    end
+
+    if asset.key?(:max_size) && !(asset[:max_size].is_a?(Integer) && asset[:max_size] > 0)
+      errors << "#{prefix}: max_size must be positive Integer (got #{asset[:max_size].inspect})"
+    end
+  end
+end
+
+if errors.empty?
+  puts "OK — #{@languages.count} languages, #{@languages.sum { |l| Array(l[:assets]).size }} asset declarations validated."
+  exit 0
+else
+  warn "active.rb has #{errors.size} problem(s):"
+  errors.each { |e| warn "  - #{e}" }
+  exit 1
+end
+```
+
+CI runs `bundle exec ruby bin/lint-active-rb` before the docker
+build/push step. Caught at PR time, not at deploy time.
+
+Both layers share validation logic. For v1 the duplication is small
+enough to tolerate; if a third caller appears, extract to
+`db/languages/asset_validator.rb` and have both call it.
+
+## API surface
+
+### `GET /submissions/:token` (extended)
+
+Existing endpoint. Adds an `assets` field to the submission JSON when
+requested via `fields=`:
+
+```json
+GET /submissions/<token>?fields=stdout,status,assets
+
+{
+  "stdout": "Time\t a b | y\n----------------\n0\t 0 0 | 0\n...",
+  "status": { "id": 3, "description": "Accepted" },
+  "assets": [
+    {
+      "logical_name": "wave.vcd",
+      "source_filename": "wave.vcd",
+      "size_bytes": 440,
+      "error": null
+    }
+  ]
+}
+```
+
+The `assets` field returns **metadata only**, no `data`. This keeps
+typical submission JSON small (most consumers want to know "was a
+waveform produced?" + size, not the bytes).
+
+Over-cap example:
+
+```json
+{
+  "assets": [
+    {
+      "logical_name": "wave.vcd",
+      "source_filename": "wave.vcd",
+      "size_bytes": 55340,
+      "error": "size_limit_exceeded",
+      "error_detail": "55340 bytes exceeds 20480 byte cap"
+    }
+  ]
+}
+```
+
+### `GET /submissions/:token/assets/:logical_name` (new)
+
+Returns the asset content. Data is stored base64-encoded in the DB
+(see Schema), so:
+
+- `Accept: application/json` (default) → `{ "data": "<base64>" }`
+  served straight from the column, no transcoding.
+- `Accept: application/octet-stream` → controller `Base64.decode64`s
+  the column on the way out and ships the decoded bytes,
+  `Content-Type: application/octet-stream` (future: per-asset
+  content-type field).
+
+404 when:
+- Submission doesn't exist
+- Asset row doesn't exist for that `logical_name`
+- Asset row exists but `data` is null (because `error` is set)
+
+In the 404-due-to-error case, the error description is already
+visible in the submission GET response, so clients have enough
+context.
+
+## Toggles in practice
+
+| Scenario | Required setup |
+|---|---|
+| Verilog problem with waveform | Testbench includes `$dumpfile`/`$dumpvars`. Default — works out of the box. |
+| Caller doesn't want the waveform for this submission | POST body includes `"skip_assets": true`. |
+| Ops needs to tighten the cap deployment-wide | Lower `MAX_MAX_ASSET_SIZE` in `judge0.conf`. Clamps existing language declarations. |
+| Ops needs to effectively disable capture (incident response) | Set `MAX_MAX_ASSET_SIZE=0` — every file becomes over-cap, no data stored, only error rows recorded. |
+| New asset type for an unrelated language | Add `assets: [...]` to that language's entry; lint passes; deploy. No core code changes. |
+
+## Worked example: Verilog VCD round-trip
+
+1. Student submits the AND-gate DUT (`source_code`) and the testbench
+   from earlier (`stdin`) including `$dumpfile("wave.vcd"); $dumpvars(0, and_gate_tb);`.
+2. judge0 enqueues `IsolateJob`. Box has `main.v` written from
+   `source_code`.
+3. `compile_cmd` parse-checks `main.v` alone — passes.
+4. `run_cmd` does `cat > tb.v` (testbench from stdin), `iverilog
+   -g2012 -o sim.vvp main.v tb.v`, `vvp sim.vvp`. vvp writes
+   `wave.vcd` (440 bytes) to the box. stdout receives the truth
+   table; vvp exits 0.
+5. `IsolateJob#capture_assets` runs:
+   - `submission.skip_assets` is false → continue.
+   - Language 3005's `assets` is non-empty → continue.
+   - For asset `{ name: "wave.vcd", identification: '\.vcd$', max_size: 20480 }`:
+     `effective_cap = min(20480, MAX_MAX_ASSET_SIZE) = 20480`. Scan
+     box filenames against the regex → match `wave.vcd`. Stat the
+     file: 440 bytes, ≤ 20480. Read bytes, base64-encode, write a
+     `SubmissionAsset` row with `data = "JGRhdGUKCVR1ZS..."` (base64),
+     `size_bytes = 440`, `source_filename = "wave.vcd"`,
+     `error = nil`.
+6. `isolate --cleanup` wipes the box.
+7. Platform calls `GET /submissions/<token>?fields=stdout,status,assets`
+   — sees the truth table in stdout, status Accepted, one asset
+   metadata row.
+8. Platform calls `GET /submissions/<token>/assets/wave.vcd` — gets
+   the raw bytes, hands them to wavedrom-or-similar in the browser
+   for inline rendering.
+
+## Migration & rollout
+
+Order:
+
+1. Schema migrations (both: create `submission_assets`, add
+   `submissions.skip_assets`).
+2. `Config` initializer read of `MAX_MAX_ASSET_SIZE`; default 20480.
+3. `IsolateJob#capture_assets` implementation.
+4. Submissions controller: extend `fields=` allowlist with `assets`,
+   accept `skip_assets` in POST body, mount the asset-bytes endpoint.
+5. `active.rb`: add the `assets` field to the Verilog 3005 entry.
+6. `db/seeds.rb`: validation block.
+7. `bin/lint-active-rb`: standalone script.
+8. CI: invoke `bin/lint-active-rb` before docker push.
+9. `bin/newton-smoke-test`: extend Verilog 3005 case to verify a
+   waveform is captured (submit testbench with `$dumpfile`, fetch
+   submission with `fields=...,assets`, assert `assets[0].size_bytes
+   > 0`).
+10. Build + push `judge0-newton-compiler:0.29` (no change — already
+    has iverilog).
+11. Build + push `newton-judge0:0.67`. Bump compose, smoke locally,
+    then staging.
+
+Phase-3 docker tag bump is `0.66 → 0.67`. Bumping doesn't require a
+compilers image rebuild — Phase-3 is judge0-only.
+
+Backwards compatibility: existing submissions without an
+`assets` row continue to work. The new `submissions.skip_assets`
+column defaults to false, so old POST bodies (no `skip_assets`
+field) get the new "capture if language has assets declared"
+behavior automatically.
+
+Production prerequisite remains the existing AL2 → AL2023 karpenter
+NodeClass flip — same constraint as for 0.66, no new ops blocker
+introduced by this spec.
+
+## Risks and open items
+
+- **Index size.** Once all Verilog problems start producing waveforms,
+  `submission_assets` will accumulate ~10 KB / submission for the
+  median problem. At 10k Verilog submissions/day that's ~100 MB/day,
+  ~36 GB/year. Postgres handles this fine but worth budgeting in
+  storage capacity planning. If volume grows, the natural next step
+  is moving `data` to S3 with a pointer column (out of scope here —
+  see "Out of scope" below).
+- **No per-asset content-type yet.** v1 returns
+  `application/octet-stream` from the bytes endpoint. If the platform
+  UI needs to distinguish (e.g., text-rendered VCD vs binary core
+  dump), add a `content_type` column to the asset declaration in a
+  follow-up.
+- **Pre-cap reads big files.** When a language's regex matches a
+  500 MB file, IsolateJob reads `size_bytes` first via `File.size`
+  (cheap), then only reads bytes when ≤ cap. So the over-cap path
+  doesn't pull large files into memory. Worth confirming during
+  implementation.
+- **`skip_assets` enum vs boolean.** Currently boolean. If we ever
+  want per-asset opt-out (skip waveform but still capture compile
+  log), this becomes an array of logical names. Acceptable v1 wart;
+  revisit if more asset types arrive.
+- **Multi-match regex.** First alphabetically wins. If a future asset
+  type genuinely produces multiple files (e.g., per-thread profiles),
+  add `multi: true` to the declaration and write a row per match.
+  Schema already supports multiple rows per (submission_id,
+  logical_name).
+
+## Out of scope (this spec)
+
+- **External blob storage (S3 + pointer column).** Reasonable v2
+  optimization once `submission_assets.data` row sizes start
+  pressuring Postgres. Mechanism stays the same on the API side; the
+  bytes endpoint just reads from S3 instead of the column. Not a
+  concern at v1 scale.
+- **Per-asset content-type / mime negotiation.** v1 ships
+  `application/octet-stream` from the bytes endpoint. Add a
+  `content_type` field to declarations when a real consumer needs it.
+- **Authorization on the bytes endpoint.** Currently the `submissions`
+  endpoint exposes data to anyone who knows the token; assets follow
+  the same model for v1. If submissions ever get per-user auth, assets
+  inherit that automatically.
+- **GZIP-on-the-fly for the bytes endpoint.** VCD compresses ~40%; if
+  bandwidth becomes a concern, add `Accept-Encoding: gzip` handling at
+  the controller layer. Not needed at v1 scale.
+- **Per-asset `multi: true`.** Future enhancement when an asset type
+  legitimately produces multiple files.
+- **Webhook on asset capture / asset failure.** Out of scope; consumers
+  can poll the submission endpoint as today.

--- a/judge0.conf
+++ b/judge0.conf
@@ -342,6 +342,16 @@ MAX_FILE_SIZE=1048576
 # Newton override: 2 GiB cap.
 MAX_MAX_FILE_SIZE=2097152
 
+# Hard ceiling on per-submission asset size (bytes) for Phase 3 asset
+# capture. Acts as both:
+#   - the default cap when a language asset declaration in active.rb
+#     omits :max_size
+#   - the absolute clamp on any per-language max_size — a language
+#     cannot ask for a larger cap, only a smaller one
+# Mirrors the role of MAX_MAX_MEMORY_LIMIT / MAX_MAX_FILE_SIZE.
+# Newton-added knob; default 20 KB targets DSA-scale Verilog VCDs.
+MAX_MAX_ASSET_SIZE=20480
+
 # Maximum number of open file descriptors a sandboxed process can hold.
 # Default: 4096 (Newton-added knob; upstream judge0 didn't expose this).
 # R 4.5's session init opens hundreds of locale + package files; Go's

--- a/spec/db/languages/asset_validator_spec.rb
+++ b/spec/db/languages/asset_validator_spec.rb
@@ -1,0 +1,89 @@
+require "rails_helper"
+require_relative "../../../db/languages/asset_validator"
+
+RSpec.describe AssetValidator do
+  describe ".validate_language" do
+    let(:lang) { { id: 9999, name: "Test Lang" } }
+
+    it "passes when no :assets array is present" do
+      errors = described_class.validate_language(lang)
+      expect(errors).to be_empty
+    end
+
+    it "passes when :assets is an empty array" do
+      lang[:assets] = []
+      errors = described_class.validate_language(lang)
+      expect(errors).to be_empty
+    end
+
+    it "passes for a well-formed asset" do
+      lang[:assets] = [{ name: "wave.vcd", identification: '\.vcd$', max_size: 20480 }]
+      errors = described_class.validate_language(lang)
+      expect(errors).to be_empty
+    end
+
+    it "passes when :max_size is omitted" do
+      lang[:assets] = [{ name: "wave.vcd", identification: '\.vcd$' }]
+      errors = described_class.validate_language(lang)
+      expect(errors).to be_empty
+    end
+
+    it "errors when :name is missing" do
+      lang[:assets] = [{ identification: '\.vcd$' }]
+      errors = described_class.validate_language(lang)
+      expect(errors).to include(a_string_including("missing :name"))
+    end
+
+    it "errors when :name is empty string" do
+      lang[:assets] = [{ name: "", identification: '\.vcd$' }]
+      errors = described_class.validate_language(lang)
+      expect(errors).to include(a_string_including("missing :name"))
+    end
+
+    it "errors when :identification is missing" do
+      lang[:assets] = [{ name: "wave.vcd" }]
+      errors = described_class.validate_language(lang)
+      expect(errors).to include(a_string_including("missing :identification"))
+    end
+
+    it "errors when :identification is not a valid regex" do
+      lang[:assets] = [{ name: "wave.vcd", identification: '[unclosed' }]
+      errors = described_class.validate_language(lang)
+      expect(errors).to include(a_string_including("not valid regex"))
+    end
+
+    it "errors when :max_size is negative" do
+      lang[:assets] = [{ name: "wave.vcd", identification: '\.vcd$', max_size: -1 }]
+      errors = described_class.validate_language(lang)
+      expect(errors).to include(a_string_including("max_size must be positive Integer"))
+    end
+
+    it "errors when :max_size is zero" do
+      lang[:assets] = [{ name: "wave.vcd", identification: '\.vcd$', max_size: 0 }]
+      errors = described_class.validate_language(lang)
+      expect(errors).to include(a_string_including("max_size must be positive Integer"))
+    end
+
+    it "errors when :max_size is a String" do
+      lang[:assets] = [{ name: "wave.vcd", identification: '\.vcd$', max_size: "20480" }]
+      errors = described_class.validate_language(lang)
+      expect(errors).to include(a_string_including("max_size must be positive Integer"))
+    end
+
+    it "reports multiple errors per asset declaration" do
+      lang[:assets] = [{ identification: '[broken', max_size: -1 }]
+      errors = described_class.validate_language(lang)
+      expect(errors.size).to eq(3) # missing name + invalid regex + bad max_size
+    end
+
+    it "reports errors for each asset in a multi-asset declaration" do
+      lang[:assets] = [
+        { name: "good.txt", identification: '\.txt$' },          # valid
+        { name: "bad",      identification: '[unclosed' },       # invalid regex
+      ]
+      errors = described_class.validate_language(lang)
+      expect(errors.size).to eq(1)
+      expect(errors.first).to include("not valid regex")
+    end
+  end
+end

--- a/spec/services/asset_capture_spec.rb
+++ b/spec/services/asset_capture_spec.rb
@@ -1,0 +1,121 @@
+require "rails_helper"
+require "tmpdir"
+require "fileutils"
+require "base64"
+
+RSpec.describe AssetCapture do
+  let(:submission) { create(:valid_submission) }
+
+  around do |example|
+    Dir.mktmpdir do |dir|
+      @box = dir
+      example.run
+    end
+  end
+
+  def declaration(overrides = {})
+    { name: "wave.vcd", identification: '\.vcd$', max_size: 20480 }.merge(overrides)
+  end
+
+  it "writes no row when no file matches the regex" do
+    File.write(File.join(@box, "main.v"), "module x; endmodule")
+    described_class.new(box_path: @box, submission: submission, declarations: [declaration]).call
+    expect(submission.submission_assets.count).to eq(0)
+  end
+
+  it "writes no row when declarations is empty" do
+    File.write(File.join(@box, "wave.vcd"), "x")
+    described_class.new(box_path: @box, submission: submission, declarations: []).call
+    expect(submission.submission_assets.count).to eq(0)
+  end
+
+  it "stores base64 data and raw size when file is within cap" do
+    raw = "$date\nFri\n$end\n" # 17 bytes
+    File.write(File.join(@box, "wave.vcd"), raw)
+
+    described_class.new(box_path: @box, submission: submission, declarations: [declaration]).call
+
+    a = submission.submission_assets.first
+    expect(a.logical_name).to eq("wave.vcd")
+    expect(a.source_filename).to eq("wave.vcd")
+    expect(a.size_bytes).to eq(raw.bytesize)
+    expect(a.error).to be_nil
+    expect(Base64.decode64(a.data)).to eq(raw)
+  end
+
+  it "writes an error row when file exceeds the per-asset cap" do
+    raw = "x" * 30_000
+    File.write(File.join(@box, "wave.vcd"), raw)
+
+    described_class.new(box_path: @box, submission: submission, declarations: [declaration(max_size: 20480)]).call
+
+    a = submission.submission_assets.first
+    expect(a.data).to be_nil
+    expect(a.size_bytes).to eq(30_000)
+    expect(a.error).to eq("size_limit_exceeded")
+    expect(a.error_detail).to include("30000").and include("20480")
+  end
+
+  it "clamps a language max_size that exceeds MAX_MAX_ASSET_SIZE" do
+    raw = "x" * 30_000
+    File.write(File.join(@box, "wave.vcd"), raw)
+
+    stub_const("Config::MAX_MAX_ASSET_SIZE", 20480)
+    described_class.new(box_path: @box, submission: submission, declarations: [declaration(max_size: 1_000_000)]).call
+
+    a = submission.submission_assets.first
+    expect(a.error).to eq("size_limit_exceeded")
+    expect(a.error_detail).to include("20480") # ceiling, not 1_000_000
+  end
+
+  it "uses MAX_MAX_ASSET_SIZE when declaration omits max_size" do
+    raw = "x" * 100
+    File.write(File.join(@box, "wave.vcd"), raw)
+
+    stub_const("Config::MAX_MAX_ASSET_SIZE", 20480)
+    described_class.new(
+      box_path: @box,
+      submission: submission,
+      declarations: [{ name: "wave.vcd", identification: '\.vcd$' }]
+    ).call
+
+    a = submission.submission_assets.first
+    expect(a.error).to be_nil
+    expect(a.size_bytes).to eq(100)
+  end
+
+  it "picks first match alphabetically when regex matches multiple files" do
+    File.write(File.join(@box, "z.vcd"), "z")
+    File.write(File.join(@box, "a.vcd"), "a")
+    File.write(File.join(@box, "m.vcd"), "m")
+
+    described_class.new(box_path: @box, submission: submission, declarations: [declaration]).call
+
+    a = submission.submission_assets.first
+    expect(a.source_filename).to eq("a.vcd")
+    expect(Base64.decode64(a.data)).to eq("a")
+  end
+
+  it "skips an asset declaration with invalid regex without raising" do
+    File.write(File.join(@box, "wave.vcd"), "x")
+
+    described_class.new(
+      box_path: @box,
+      submission: submission,
+      declarations: [{ name: "wave.vcd", identification: "[broken" }]
+    ).call
+
+    expect(submission.submission_assets.count).to eq(0)
+  end
+
+  it "ignores subdirectories when matching filenames" do
+    Dir.mkdir(File.join(@box, "sub.vcd")) # directory whose name happens to match
+    File.write(File.join(@box, "sub.vcd", "inner.vcd"), "inner")
+    File.write(File.join(@box, "real.vcd"), "real")
+
+    described_class.new(box_path: @box, submission: submission, declarations: [declaration]).call
+
+    a = submission.submission_assets.first
+    expect(a.source_filename).to eq("real.vcd")
+  end
+end


### PR DESCRIPTION
## Summary

Adds a language-agnostic mechanism for capturing artifacts (binary or text) produced inside the isolate sandbox during a submission run, persisting them in a new `submission_assets` table, and surfacing them via the judge0 API. Verilog 3005 is the first language to opt in — `.vcd` waveforms produced by testbenches that call `$dumpfile`/`$dumpvars` now travel back to the platform UI for inline rendering.

**Core changes:**
- New `submission_assets` table (`logical_name`, `source_filename`, `data` as base64 text, `size_bytes`, `error`, `error_detail`) with FK + `ON DELETE CASCADE` to submissions.
- New `submissions.skip_assets` boolean for per-call opt-out.
- New `languages.assets` text column (YAML-serialized array of declarations from `active.rb`).
- `active.rb` schema: each language entry may declare `assets: [{ name:, identification:, max_size? }]` where `identification` is a Ruby regex.
- New `MAX_MAX_ASSET_SIZE` env knob (`judge0.conf` + `Config`), default 20 KB. Single global cap acting as both the default-when-omitted and the hard ceiling.
- New `AssetCapture` service called by `IsolateJob` between `verify` and `cleanup`. Two-level decision: caller opt-out (`skip_assets`) + language opt-in (presence of `assets:` array).
- New `AssetValidator` (pure-Ruby, no Rails dep) wired into both `db/seeds.rb` (fail-fast at container boot) and `bin/lint-active-rb` (CI gate).
- Extended submission GET — `fields=...,assets` returns metadata array (no `data`).
- New endpoint `GET /submissions/:token/assets/:logical_name` — JSON `{"data": "<base64>"}` by default, decoded bytes via `Accept: application/octet-stream`.

**Verilog 3005 opt-in:**
```ruby
assets: [
  { name: "wave.vcd", identification: '\.vcd$', max_size: 20480 }
]
```
Author writes `$dumpfile("anything.vcd")` + `$dumpvars(...)` in the testbench → file appears in box → `AssetCapture` regex-matches → row written. Author writes nothing → no row, zero perf cost.

## Why

Phase 3 of the Verilog integration (Phases 1+2 = compilers `:0.29` + judge0 `:0.66`, both already merged). Verilog learning is half-blind without waveform inspection; iverilog already produces VCDs natively but the box wipe was destroying them before judge0 could surface them.

Path I (DB-backed) chosen over Path II (base64 markers in stdout) because the platform's grader compares stdout against `expected_output` byte-for-byte — marker pollution would either break grading or force every consumer to learn the marker convention.

Full design rationale + alternatives considered + risks + future Phase 4 expansion paths in `docs/superpowers/specs/2026-05-05-submission-assets-design.md`. 18-task implementation plan with TDD checkpoints in `docs/superpowers/plans/2026-05-05-submission-assets.md`.

## Test plan

Build on EC2 (Mac dev build deferred per the user's preference for amd64-on-EC2-only):

- [x] amd64 build: `docker buildx build --platform linux/amd64 -f NewtonDockerfile -t newtonschool/newton-judge0:0.67 --load .` (in tmux)
- [x] Bring up dev compose with the freshly built `:0.67` image (compose file already updated).
- [x] Run RSpec on the new units: `bundle exec rspec spec/db/languages/asset_validator_spec.rb spec/services/asset_capture_spec.rb` — expect 13+9 examples, all green.
- [x] Run the lint script: `./bin/lint-active-rb` — expect "OK — 22 languages, 1 asset declarations validated."
- [x] End-to-end smoke: `JUDGE0_URL=http://localhost:2358 ./bin/newton-smoke-test` — expect **24 PASS / 0 FAIL / 0 SKIP** on amd64. The new "Verilog 3005 with wave.vcd asset" entry submits an AND-gate DUT + `$dumpfile` testbench, then asserts both stdout grading + asset metadata + bytes endpoint round-trip.
- [x] Manual sanity: submit Verilog 3005 with a real DUT + `$dumpfile` testbench, fetch `GET /submissions/<token>?fields=stdout,status,assets` and confirm the asset metadata; then `GET /submissions/<token>/assets/wave.vcd` returns valid VCD content.
- [x] Push to Docker Hub: `docker push newtonschool/newton-judge0:0.67`.
- [x] Deploy to staging and re-run smoke against `https://judge0-public.staging-newtonschool.co` — expect **24/0/0**.

## Validation strategy

Two layers, same `AssetValidator` logic:
1. **Layer 1 — `db/seeds.rb`**: container boot fails if any `assets:` declaration is malformed (missing fields, unparseable regex, non-positive `max_size`). Bad config never reaches production.
2. **Layer 2 — `bin/lint-active-rb`**: standalone CLI, no Rails boot required; intended for CI before docker push so problems are caught at PR time.

## Outcome rows

| Box state | Row written? | Fields populated |
|---|---|---|
| No file matches regex | no | — |
| Match within cap, readable | yes | `data` (base64), `size_bytes` (raw), `source_filename`, `error = nil` |
| Match exceeds cap | yes | `data = nil`, `size_bytes` = actual, `error = "size_limit_exceeded"`, detail with the math |
| Match unreadable (I/O error) | yes | `data = nil`, `size_bytes = 0`, `error = "read_error"`, detail = OS message |

The error rows are the spec's deliberate concession to over-cap surfacing — the platform UI can render "produced 55 KB — exceeded 20 KB display cap; reduce `$dumpvars` scope" rather than silently showing nothing.

## Out of scope

- **External blob storage (S3 + pointer column)** — natural v2 optimization once row sizes start pressuring Postgres. Not a v1 concern at projected ~30 GB/year.
- **Per-asset content-type / mime negotiation** — v1 ships `application/octet-stream` from the bytes endpoint.
- **Per-asset `multi: true` declarations** — first match alphabetically wins for v1; revisit if future asset types legitimately produce multiple files.
- **Production redeploy** — same prerequisite as 0.66 (AL2 → AL2023 karpenter NodeClass flip), already tracked separately. No new prod blocker introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)