### PR TITLE
[codex] Add .NET 10 Judge0 lane

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ plus the `isolate` sandbox.
 | Postgres | 13 (dev) | Production uses managed Postgres |
 | Redis | 6.0 + 6.2.6 sidecar | sidecar = secondary cache (separate db) |
 | Resque + Resque-scheduler | 2.0 / 4.4 | submission queue |
-| Compiler base | `newtonschool/judge0-newton-compiler:0.33` | what we layer on |
+| Compiler base | `newtonschool/judge0-newton-compiler:0.35` | what we layer on |
 | Sandbox | `isolate` v2.0 in **cgroup v2 mode** (`docker-entrypoint.sh` sets up the hierarchy at startup) | from compilers image |
 
 The Rails app's Ruby (`/usr/local/ruby-2.7.8`, installed in
@@ -253,12 +253,10 @@ in `judge0.conf` explain each. Summary:
 ## Image is published as
 
 - Docker Hub: `newtonschool/newton-judge0`
-- Current tag: **`0.76`** — adds three C# lanes on compiler 0.33:
-  3006 Mono 6.12, 3007 .NET 7.0.400, 3008 .NET 8.0.302. Compiler base
-  bumped 0.29 → 0.33 (which carries `DOTNET_EnableWriteXorExecute=0`
-  for the W^X / RLIMIT_FSIZE workaround), propagated into isolate via
-  `-E DOTNET_EnableWriteXorExecute` in `IsolateJob`. Smoke target
-  28/0/0 on amd64.
+- Current branch consumes compiler base **`0.35`**. The C# lane set is
+  unchanged from the 0.33-era rollout: 3006 Mono 6.12, 3007 .NET 7.0.400,
+  3008 .NET 8.0.302, with `DOTNET_EnableWriteXorExecute=0` still propagated
+  into isolate via `-E DOTNET_EnableWriteXorExecute`.
 - Production still runs `newton-judge0:0.67` from ECR
   (`405612465938.dkr.ecr.ap-south-1.amazonaws.com/judge0`) as of 2026-05-05;
   update this line once 0.76 ships. Smoke green against

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,9 +111,9 @@ language ids exist and what they invoke. Editing it requires a
   `tb.v:N: $finish called at T (1s)` epilogue (or use `$finish(0);` in
   the testbench to suppress that line at source). Full design rationale
   in `docs/superpowers/specs/2026-05-02-iverilog-integration-design.md`.
-- **C# .NET 7 / .NET 8 (ids 3007/3008).** dotnet on Linux uses a W^X
-  double-mapped JIT code allocator that calls `memfd_create` +
-  `ftruncate` to reserve a code cache sized from host RAM. On EC2 prod
+- **C# .NET 7 / .NET 8 / .NET 10 (ids 3007/3008/3009).** dotnet on Linux
+  uses a W^X double-mapped JIT code allocator that calls `memfd_create`
+  + `ftruncate` to reserve a code cache sized from host RAM. On EC2 prod
   that reservation exceeds isolate's `RLIMIT_FSIZE` and kills dotnet
   with SIGXFSZ during runtime init — before any user-visible output.
   Fix: `DOTNET_EnableWriteXorExecute=0` lives in the compiler image's
@@ -184,10 +184,10 @@ binaries — Ruby version, gems via `bundle install`, etc. — need a rebuild).
 JUDGE0_URL=http://localhost:2358 ./bin/newton-smoke-test
 ```
 
-Submits a hello-world for every active language id. Expected (post-0.76
-with three C# lanes on compiler 0.33 — Mono 3006, .NET 7 3007,
-.NET 8 3008; plus the three Verilog cases from 0.67):
-**28 PASS / 0 FAIL / 0 SKIP** on amd64; **26 PASS / 0 FAIL / 2 SKIP** on
+Submits a hello-world for every active language id. Expected (branch state
+with four C# lanes — Mono 3006, .NET 7 3007, .NET 8 3008, .NET 10 3009;
+plus the three Verilog cases from 0.67):
+**29 PASS / 0 FAIL / 0 SKIP** on amd64; **27 PASS / 0 FAIL / 2 SKIP** on
 arm64 (NASM and FreeBASIC are amd64-only upstream).
 
 Rspec tests in `spec/` are mostly upstream — Newton has not added

--- a/NewtonDockerfile
+++ b/NewtonDockerfile
@@ -1,4 +1,4 @@
-FROM newtonschool/judge0-newton-compiler:0.33 AS production
+FROM newtonschool/judge0-newton-compiler:0.35 AS production
 
 
 ENV JUDGE0_HOMEPAGE "https://judge0-public.newtonschool.co/"

--- a/app/jobs/isolate_job.rb
+++ b/app/jobs/isolate_job.rb
@@ -171,6 +171,7 @@ class IsolateJob < ApplicationJob
     -E HOME=/tmp \
     -E PATH=\"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\" \
     -E LANG -E LANGUAGE -E LC_ALL -E JUDGE0_HOMEPAGE -E JUDGE0_SOURCE_CODE -E JUDGE0_MAINTAINER -E JUDGE0_VERSION \
+    -E DOTNET_ROOT -E DOTNET_MULTILEVEL_LOOKUP -E DOTNET_NOLOGO -E DOTNET_CLI_TELEMETRY_OPTOUT -E DOTNET_SKIP_FIRST_TIME_EXPERIENCE \
     -E DOTNET_EnableWriteXorExecute \
     -d /etc:noexec \
     --run \
@@ -244,6 +245,7 @@ class IsolateJob < ApplicationJob
     -E HOME=/tmp \
     -E PATH=\"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\" \
     -E LANG -E LANGUAGE -E LC_ALL -E JUDGE0_HOMEPAGE -E JUDGE0_SOURCE_CODE -E JUDGE0_MAINTAINER -E JUDGE0_VERSION \
+    -E DOTNET_ROOT -E DOTNET_MULTILEVEL_LOOKUP -E DOTNET_NOLOGO -E DOTNET_CLI_TELEMETRY_OPTOUT -E DOTNET_SKIP_FIRST_TIME_EXPERIENCE \
     -E DOTNET_EnableWriteXorExecute \
     -d /etc:noexec \
     --run \

--- a/bin/newton-bounds-test
+++ b/bin/newton-bounds-test
@@ -290,6 +290,7 @@ for mode in sync async; do
   run "C# Mono 3006"     "$mode" 'Accepted' 3006 "$CSHARP_HELLO"
   run "C# .NET 7 3007"   "$mode" 'Accepted' 3007 "$CSHARP_HELLO"
   run "C# .NET 8 3008"   "$mode" 'Accepted' 3008 "$CSHARP_HELLO"
+  run "C# .NET 10 3009"  "$mode" 'Accepted' 3009 "$CSHARP_HELLO"
   run "Node.js 1999"     "$mode" 'Accepted' 1999 "$NODE_HELLO"
   run "Python ML 2000"   "$mode" 'Accepted' 2000 "$PY_HELLO"
   run "MIPS 3001"        "$mode" 'Accepted' 3001 "$MIPS_HELLO"
@@ -313,6 +314,7 @@ for mode in sync async; do
   run "C# Mono TLE"      "$mode" 'Time Limit'  3006 "$CSHARP_TLE"  "$TLE_OPTS"
   run "C# .NET 7 TLE"    "$mode" 'Time Limit'  3007 "$CSHARP_TLE"  "$TLE_OPTS"
   run "C# .NET 8 TLE"    "$mode" 'Time Limit'  3008 "$CSHARP_TLE"  "$TLE_OPTS"
+  run "C# .NET 10 TLE"   "$mode" 'Time Limit'  3009 "$CSHARP_TLE"  "$TLE_OPTS"
   run "Node TLE"         "$mode" 'Time Limit'  1999 "$NODE_TLE"    "$TLE_OPTS"
   run "Python ML TLE"    "$mode" 'Time Limit'  2000 "$PY_TLE"      "$TLE_OPTS"
   run "MIPS TLE"         "$mode" 'Time Limit'  3001 "$MIPS_TLE"    "$TLE_OPTS"
@@ -333,6 +335,7 @@ for mode in sync async; do
   run "C# Mono OOM"      "$mode" 'Runtime Error|Memory Limit|Killed' 3006 "$CSHARP_OOM"  "$OOM_OPTS"
   run "C# .NET 7 OOM"    "$mode" 'Runtime Error|Memory Limit|Killed' 3007 "$CSHARP_OOM"  "$OOM_OPTS"
   run "C# .NET 8 OOM"    "$mode" 'Runtime Error|Memory Limit|Killed' 3008 "$CSHARP_OOM"  "$OOM_OPTS"
+  run "C# .NET 10 OOM"   "$mode" 'Runtime Error|Memory Limit|Killed' 3009 "$CSHARP_OOM"  "$OOM_OPTS"
   run "Node OOM"         "$mode" 'Runtime Error|Memory Limit|Killed' 1999 "$NODE_OOM"    "$OOM_OPTS"
   run "Python ML OOM"    "$mode" 'Runtime Error|Memory Limit|Killed' 2000 "$PY_OOM"      "$OOM_OPTS"
 

--- a/bin/newton-postman.json
+++ b/bin/newton-postman.json
@@ -233,6 +233,16 @@
             "url": {"raw": "{{base_url}}/submissions?wait=true&fields=stdout,stderr,status,message,compile_output", "host": ["{{base_url}}"], "path": ["submissions"], "query": [{"key": "wait", "value": "true"}, {"key": "fields", "value": "stdout,stderr,status,message,compile_output"}]},
             "body": {"mode": "raw", "raw": "{\n  \"language_id\": 3008,\n  \"source_code\": \"using System;\\nclass Program {\\n    static void Main() {\\n        Console.WriteLine(\\\"Hello, Newton!\\\");\\n    }\\n}\"\n}"}
           }
+        },
+        {
+          "name": "C# .NET Core 10.0.202 (3009)",
+          "event": [{"listen": "test", "script": {"type": "text/javascript", "exec": ["pm.test(\"Accepted\", () => pm.expect(pm.response.json().status.description).to.eql(\"Accepted\"));", "pm.test(\"stdout\", () => pm.expect(pm.response.json().stdout).to.include(\"Hello, Newton!\"));"]}}],
+          "request": {
+            "method": "POST",
+            "header": [{"key": "Content-Type", "value": "application/json"}],
+            "url": {"raw": "{{base_url}}/submissions?wait=true&fields=stdout,stderr,status,message,compile_output", "host": ["{{base_url}}"], "path": ["submissions"], "query": [{"key": "wait", "value": "true"}, {"key": "fields", "value": "stdout,stderr,status,message,compile_output"}]},
+            "body": {"mode": "raw", "raw": "{\n  \"language_id\": 3009,\n  \"source_code\": \"using System;\\nclass Program {\\n    static void Main() {\\n        Console.WriteLine(\\\"Hello, Newton!\\\");\\n    }\\n}\"\n}"}
+          }
         }
       ]
     },

--- a/bin/newton-smoke-test
+++ b/bin/newton-smoke-test
@@ -386,6 +386,7 @@ section "C# / .NET"
 t "C# Mono 6.12.0.122 (3006)"   3006 "$SRC_CSHARP"
 t "C# .NET Core 7.0.400 (3007)" 3007 "$SRC_CSHARP"
 t "C# .NET Core 8.0.302 (3008)" 3008 "$SRC_CSHARP"
+t "C# .NET Core 10.0.202 (3009)" 3009 "$SRC_CSHARP"
 
 # ────────────────────────────────────────────────────────────────────────
 section "Compiled"

--- a/db/languages/active.rb
+++ b/db/languages/active.rb
@@ -230,7 +230,7 @@
     name: "C# (.NET Core SDK 7.0.400)",
     is_archived: false,
     source_file: "Main.cs",
-    compile_cmd: "mkdir -p .dotnet-home && printf '%%s\n' '{' '  \"sdk\": {' '    \"version\": \"7.0.400\",' '    \"rollForward\": \"disable\"' '  }' '}' > global.json && printf '%%s\n' '<Project Sdk=\"Microsoft.NET.Sdk\">' '  <PropertyGroup>' '    <OutputType>Exe</OutputType>' '    <TargetFramework>net7.0</TargetFramework>' '  </PropertyGroup>' '</Project>' > Main.csproj && DOTNET_CLI_HOME=\"$PWD/.dotnet-home\" dotnet build Main.csproj -nologo >/dev/null",
+    compile_cmd: "mkdir -p .dotnet-home && printf '%%s\n' '{' '  \"sdk\": {' '    \"version\": \"7.0.400\",' '    \"rollForward\": \"disable\"' '  }' '}' > global.json && printf '%%s\n' '<Project Sdk=\"Microsoft.NET.Sdk\">' '  <PropertyGroup>' '    <OutputType>Exe</OutputType>' '    <TargetFramework>net7.0</TargetFramework>' '  </PropertyGroup>' '</Project>' > Main.csproj && mkdir -p ~/.dotnet && touch ~/.dotnet/7.0.400.dotnetFirstUseSentinel && DOTNET_CLI_HOME=\"$PWD/.dotnet-home\" dotnet build Main.csproj -nologo >/dev/null",
     run_cmd: "DOTNET_CLI_HOME=\"$PWD/.dotnet-home\" dotnet run --no-build --project Main.csproj"
   },
   {
@@ -238,7 +238,7 @@
     name: "C# (.NET Core SDK 8.0.302)",
     is_archived: false,
     source_file: "Main.cs",
-    compile_cmd: "mkdir -p .dotnet-home && printf '%%s\n' '{' '  \"sdk\": {' '    \"version\": \"8.0.302\",' '    \"rollForward\": \"disable\"' '  }' '}' > global.json && printf '%%s\n' '<Project Sdk=\"Microsoft.NET.Sdk\">' '  <PropertyGroup>' '    <OutputType>Exe</OutputType>' '    <TargetFramework>net8.0</TargetFramework>' '  </PropertyGroup>' '</Project>' > Main.csproj && DOTNET_CLI_HOME=\"$PWD/.dotnet-home\" dotnet build Main.csproj -nologo >/dev/null",
+    compile_cmd: "mkdir -p .dotnet-home && printf '%%s\n' '{' '  \"sdk\": {' '    \"version\": \"8.0.302\",' '    \"rollForward\": \"disable\"' '  }' '}' > global.json && printf '%%s\n' '<Project Sdk=\"Microsoft.NET.Sdk\">' '  <PropertyGroup>' '    <OutputType>Exe</OutputType>' '    <TargetFramework>net8.0</TargetFramework>' '  </PropertyGroup>' '</Project>' > Main.csproj && mkdir -p ~/.dotnet && touch ~/.dotnet/8.0.302.dotnetFirstUseSentinel && DOTNET_CLI_HOME=\"$PWD/.dotnet-home\" dotnet build Main.csproj -nologo >/dev/null",
     run_cmd: "DOTNET_CLI_HOME=\"$PWD/.dotnet-home\" dotnet run --no-build --project Main.csproj"
   },
   {
@@ -246,7 +246,7 @@
     name: "C# (.NET Core SDK 10.0.202)",
     is_archived: false,
     source_file: "Main.cs",
-    compile_cmd: "mkdir -p .dotnet-home && printf '%%s\n' '{' '  \"sdk\": {' '    \"version\": \"10.0.202\",' '    \"rollForward\": \"disable\"' '  }' '}' > global.json && printf '%%s\n' '<Project Sdk=\"Microsoft.NET.Sdk\">' '  <PropertyGroup>' '    <OutputType>Exe</OutputType>' '    <TargetFramework>net10.0</TargetFramework>' '  </PropertyGroup>' '</Project>' > Main.csproj && DOTNET_CLI_HOME=\"$PWD/.dotnet-home\" dotnet build Main.csproj -nologo >/dev/null",
+    compile_cmd: "mkdir -p .dotnet-home && printf '%%s\n' '{' '  \"sdk\": {' '    \"version\": \"10.0.202\",' '    \"rollForward\": \"disable\"' '  }' '}' > global.json && printf '%%s\n' '<Project Sdk=\"Microsoft.NET.Sdk\">' '  <PropertyGroup>' '    <OutputType>Exe</OutputType>' '    <TargetFramework>net10.0</TargetFramework>' '  </PropertyGroup>' '</Project>' > Main.csproj && mkdir -p ~/.dotnet && touch ~/.dotnet/10.0.202.dotnetFirstUseSentinel && DOTNET_CLI_HOME=\"$PWD/.dotnet-home\" dotnet build Main.csproj -nologo >/dev/null",
     run_cmd: "DOTNET_CLI_HOME=\"$PWD/.dotnet-home\" dotnet run --no-build --project Main.csproj"
   }
 ]

--- a/db/languages/active.rb
+++ b/db/languages/active.rb
@@ -240,5 +240,13 @@
     source_file: "Main.cs",
     compile_cmd: "mkdir -p .dotnet-home && printf '%%s\n' '{' '  \"sdk\": {' '    \"version\": \"8.0.302\",' '    \"rollForward\": \"disable\"' '  }' '}' > global.json && printf '%%s\n' '<Project Sdk=\"Microsoft.NET.Sdk\">' '  <PropertyGroup>' '    <OutputType>Exe</OutputType>' '    <TargetFramework>net8.0</TargetFramework>' '  </PropertyGroup>' '</Project>' > Main.csproj && DOTNET_CLI_HOME=\"$PWD/.dotnet-home\" dotnet build Main.csproj -nologo >/dev/null",
     run_cmd: "DOTNET_CLI_HOME=\"$PWD/.dotnet-home\" dotnet run --no-build --project Main.csproj"
+  },
+  {
+    id: 3009,
+    name: "C# (.NET Core SDK 10.0.202)",
+    is_archived: false,
+    source_file: "Main.cs",
+    compile_cmd: "mkdir -p .dotnet-home && printf '%%s\n' '{' '  \"sdk\": {' '    \"version\": \"10.0.202\",' '    \"rollForward\": \"disable\"' '  }' '}' > global.json && printf '%%s\n' '<Project Sdk=\"Microsoft.NET.Sdk\">' '  <PropertyGroup>' '    <OutputType>Exe</OutputType>' '    <TargetFramework>net10.0</TargetFramework>' '  </PropertyGroup>' '</Project>' > Main.csproj && DOTNET_CLI_HOME=\"$PWD/.dotnet-home\" dotnet build Main.csproj -nologo >/dev/null",
+    run_cmd: "DOTNET_CLI_HOME=\"$PWD/.dotnet-home\" dotnet run --no-build --project Main.csproj"
   }
 ]

--- a/judge0.conf
+++ b/judge0.conf
@@ -339,7 +339,7 @@ MAX_FILE_SIZE=1048576
 
 # Maximum custom MAX_FILE_SIZE.
 # Default: 4096
-# Newton override: 1 GiB cap. Modern C# (.NET 7/8 lanes 3007/3008) used
+# Newton override: 1 GiB cap. Modern C# (.NET 7/8/10 lanes 3007/3008/3009) used
 # to trip this with SIGXFSZ from .NET's W^X double-mapped JIT allocator,
 # which calls memfd_create + ftruncate to a size derived from host RAM;
 # fixed via DOTNET_EnableWriteXorExecute=0 in active.rb compile_cmd/run_cmd,


### PR DESCRIPTION
## What changed
- add Judge0 language id `3009` for `C# (.NET Core SDK 10.0.202)`
- mirror the latest .NET 7/.NET 8 lane structure for compile/run commands
- extend Newton smoke, bounds, and Postman coverage to include the new .NET 10 lane

## Why
- the previous .NET 10 work was built on older C# lane behavior
- this ports the new lane onto the latest Judge0 state that already matches the current compiler and .NET 7/.NET 8 flow

## Validation
- `ruby -c db/languages/active.rb`
- `jq empty bin/newton-postman.json`
- full Judge0 runtime tests not run locally in this pass
