### PR TITLE
Per-language env: array on active.rb for isolate -E propagation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,12 +117,27 @@ language ids exist and what they invoke. Editing it requires a
   that reservation exceeds isolate's `RLIMIT_FSIZE` and kills dotnet
   with SIGXFSZ during runtime init — before any user-visible output.
   Fix: `DOTNET_EnableWriteXorExecute=0` lives in the compiler image's
-  Tier 12 ENV (compiler 0.33+), and `IsolateJob` propagates it via
-  `-E DOTNET_EnableWriteXorExecute` on both compile and run commands.
-  Without the `-E` propagation it doesn't reach the sandbox (isolate
-  strips env by default). Diagnostic fingerprint when broken: compile
-  exits 153 (=128+25=SIGXFSZ) with empty stdout/stderr. Mono (3006)
-  uses a different runtime and doesn't need this.
+  Tier 12 ENV (compiler 0.33+); the per-language `env:` array on each
+  .NET record (see "Per-language env propagation" below) declares it
+  alongside `DOTNET_NOLOGO` and `DOTNET_CLI_TELEMETRY_OPTOUT`, and
+  `IsolateJob` re-exposes those names to the sandbox via `-E NAME` on
+  both compile and run. Without that propagation isolate strips them.
+  Diagnostic fingerprint when broken: compile exits 153 (=128+25=
+  SIGXFSZ) with empty stdout/stderr. Mono (3006) uses a different
+  runtime and ships no `env:` array.
+- **Per-language env propagation (`env:` on active.rb).** Languages
+  with runtime-specific environment needs (e.g. .NET's
+  `DOTNET_EnableWriteXorExecute`) declare an `env:` array of bare env
+  var NAMES on their `active.rb` record. `IsolateJob#language_env_flags`
+  expands those into `-E NAME` flags, splicing them into both compile
+  and run isolate commands. Values are sourced from the compiler
+  image's Dockerfile ENV — `active.rb` only declares which names to
+  propagate (the NAME-only form, not `NAME=value`). Validation
+  (`EnvValidator`) runs at seed time and via `bin/lint-active-rb`:
+  must be an Array of String, each entry a POSIX-style env var name
+  (`[A-Za-z_][A-Za-z0-9_]*` — mixed case allowed because .NET names
+  aren't all-uppercase). Languages with no env requirements simply
+  omit the key.
 - **Submission assets (Phase 3, new in 0.67).** Languages may declare
   an `assets:` array in `active.rb` (Verilog 3005 declares `wave.vcd`
   with regex `\.vcd$`). After `run_cmd` exits, `IsolateJob` calls

--- a/app/jobs/isolate_job.rb
+++ b/app/jobs/isolate_job.rb
@@ -171,7 +171,7 @@ class IsolateJob < ApplicationJob
     -E HOME=/tmp \
     -E PATH=\"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\" \
     -E LANG -E LANGUAGE -E LC_ALL -E JUDGE0_HOMEPAGE -E JUDGE0_SOURCE_CODE -E JUDGE0_MAINTAINER -E JUDGE0_VERSION \
-    -E DOTNET_EnableWriteXorExecute \
+    #{language_env_flags} \
     -d /etc:noexec \
     --run \
     -- /bin/bash compile > #{compile_output_file} \
@@ -244,7 +244,7 @@ class IsolateJob < ApplicationJob
     -E HOME=/tmp \
     -E PATH=\"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\" \
     -E LANG -E LANGUAGE -E LC_ALL -E JUDGE0_HOMEPAGE -E JUDGE0_SOURCE_CODE -E JUDGE0_MAINTAINER -E JUDGE0_VERSION \
-    -E DOTNET_EnableWriteXorExecute \
+    #{language_env_flags} \
     -d /etc:noexec \
     --run \
     -- /bin/bash run \
@@ -308,6 +308,17 @@ class IsolateJob < ApplicationJob
     end
     `isolate #{cgroups} -b #{box_id} --cleanup`
     raise "Cleanup of sandbox #{box_id} failed." if raise_exception && Dir.exists?(workdir)
+  end
+
+  # Per-language env var propagation. isolate strips the parent env by
+  # default; `-E NAME` (no value) re-exposes the parent's value of NAME
+  # to the sandboxed process. Values are sourced from the compiler
+  # image's Dockerfile ENV (e.g. DOTNET_EnableWriteXorExecute=0); the
+  # `env:` array in active.rb declares which names to propagate.
+  # Empty/nil collapses to "" — collapsed away by the gsub(/\s+/, " ")
+  # used for logging and harmless in the shell command itself.
+  def language_env_flags
+    Array(submission.language.env).map { |name| "-E #{name}" }.join(" ")
   end
 
   # Phase 3 — capture language-declared artifacts (e.g. Verilog .vcd

--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -12,6 +12,7 @@
 
 class Language < ApplicationRecord
   serialize :assets
+  serialize :env
 
   validates :name, presence: true
   validates :source_file, :run_cmd, presence: true, unless: -> { is_project }

--- a/bin/lint-active-rb
+++ b/bin/lint-active-rb
@@ -5,21 +5,25 @@
 #   bundle exec ruby bin/lint-active-rb
 #   ./bin/lint-active-rb                    # if executable
 #
-# Intended to run in CI before `docker push` so malformed asset
+# Intended to run in CI before `docker push` so malformed asset or env
 # declarations are caught at PR time, not at container boot. The same
-# AssetValidator logic also runs in db/seeds.rb (Layer 1, runtime
-# safety) — this script is the Layer 2 / pre-merge gate.
+# validators also run in db/seeds.rb (Layer 1, runtime safety) — this
+# script is the Layer 2 / pre-merge gate.
 #
 # Per docs/superpowers/specs/2026-05-05-submission-assets-design.md.
 
 require_relative "../db/languages/active"
 require_relative "../db/languages/asset_validator"
+require_relative "../db/languages/env_validator"
 
-errors = @languages.flat_map { |lang| AssetValidator.validate_language(lang) }
+errors = @languages.flat_map do |lang|
+  AssetValidator.validate_language(lang) + EnvValidator.validate_language(lang)
+end
 
 if errors.empty?
-  decl_count = @languages.sum { |l| Array(l[:assets]).size }
-  puts "OK — #{@languages.count} languages, #{decl_count} asset declarations validated."
+  asset_count = @languages.sum { |l| Array(l[:assets]).size }
+  env_count   = @languages.sum { |l| Array(l[:env]).size }
+  puts "OK — #{@languages.count} languages, #{asset_count} asset declarations, #{env_count} env declarations validated."
   exit 0
 else
   warn "active.rb has #{errors.size} problem(s):"

--- a/db/languages/active.rb
+++ b/db/languages/active.rb
@@ -225,13 +225,24 @@
     compile_cmd: "mcs %s Main.cs",
     run_cmd: "mono Main.exe"
   },
+  # env: propagated through isolate via `-E NAME` (values from compiler
+  # image's Tier 12 ENV). EnableWriteXorExecute=0 disables .NET's W^X
+  # double-mapped JIT allocator that trips RLIMIT_FSIZE → SIGXFSZ on
+  # large-RAM hosts; NOLOGO and CLI_TELEMETRY_OPTOUT suppress first-run
+  # banner and outbound telemetry HTTP calls. SKIP_FIRST_TIME_EXPERIENCE
+  # and MULTILEVEL_LOOKUP are deliberately omitted (no-ops on .NET 7+).
   {
     id: 3007,
     name: "C# (.NET Core SDK 7.0.400)",
     is_archived: false,
     source_file: "Main.cs",
     compile_cmd: "mkdir -p .dotnet-home && printf '%%s\n' '{' '  \"sdk\": {' '    \"version\": \"7.0.400\",' '    \"rollForward\": \"disable\"' '  }' '}' > global.json && printf '%%s\n' '<Project Sdk=\"Microsoft.NET.Sdk\">' '  <PropertyGroup>' '    <OutputType>Exe</OutputType>' '    <TargetFramework>net7.0</TargetFramework>' '  </PropertyGroup>' '</Project>' > Main.csproj && DOTNET_CLI_HOME=\"$PWD/.dotnet-home\" dotnet build Main.csproj -nologo >/dev/null",
-    run_cmd: "DOTNET_CLI_HOME=\"$PWD/.dotnet-home\" dotnet run --no-build --project Main.csproj"
+    run_cmd: "DOTNET_CLI_HOME=\"$PWD/.dotnet-home\" dotnet run --no-build --project Main.csproj",
+    env: %w[
+      DOTNET_EnableWriteXorExecute
+      DOTNET_NOLOGO
+      DOTNET_CLI_TELEMETRY_OPTOUT
+    ]
   },
   {
     id: 3008,
@@ -239,6 +250,11 @@
     is_archived: false,
     source_file: "Main.cs",
     compile_cmd: "mkdir -p .dotnet-home && printf '%%s\n' '{' '  \"sdk\": {' '    \"version\": \"8.0.302\",' '    \"rollForward\": \"disable\"' '  }' '}' > global.json && printf '%%s\n' '<Project Sdk=\"Microsoft.NET.Sdk\">' '  <PropertyGroup>' '    <OutputType>Exe</OutputType>' '    <TargetFramework>net8.0</TargetFramework>' '  </PropertyGroup>' '</Project>' > Main.csproj && DOTNET_CLI_HOME=\"$PWD/.dotnet-home\" dotnet build Main.csproj -nologo >/dev/null",
-    run_cmd: "DOTNET_CLI_HOME=\"$PWD/.dotnet-home\" dotnet run --no-build --project Main.csproj"
+    run_cmd: "DOTNET_CLI_HOME=\"$PWD/.dotnet-home\" dotnet run --no-build --project Main.csproj",
+    env: %w[
+      DOTNET_EnableWriteXorExecute
+      DOTNET_NOLOGO
+      DOTNET_CLI_TELEMETRY_OPTOUT
+    ]
   }
 ]

--- a/db/languages/env_validator.rb
+++ b/db/languages/env_validator.rb
@@ -1,0 +1,49 @@
+# Pure-Ruby validator for db/languages/active.rb `env:` declarations.
+#
+# Used by:
+#   - db/seeds.rb       — runs at container boot, fails fast on bad data
+#   - bin/lint-active-rb — runs in CI, catches problems at PR time
+#
+# Deliberately depends on no Rails internals so the lint script can
+# run without booting Rails. Mirrors AssetValidator's shape.
+#
+# Contract: `env:`, if present, is an Array of String. Each string is a
+# bare environment-variable NAME (no `=value`) matching a permissive
+# POSIX form `[A-Za-z_][A-Za-z0-9_]*`. Mixed case is intentional —
+# .NET's canonical names (e.g. DOTNET_EnableWriteXorExecute) are not
+# all-caps. The NAME-only form means values are sourced from the
+# compiler image's Dockerfile ENV and propagated through isolate via
+# `-E NAME`; active.rb just declares which names to propagate.
+module EnvValidator
+  module_function
+
+  NAME_RE = /\A[A-Za-z_][A-Za-z0-9_]*\z/
+
+  # Returns Array<String> of error messages (empty array on valid).
+  def validate_language(lang)
+    errors = []
+    return errors unless lang.key?(:env)
+
+    prefix = "lang #{lang[:id]} (#{lang[:name].inspect}) env"
+
+    unless lang[:env].is_a?(Array)
+      errors << "#{prefix}: must be an Array (got #{lang[:env].class})"
+      return errors
+    end
+
+    lang[:env].each_with_index do |name, i|
+      entry_prefix = "#{prefix}[#{i}]"
+
+      unless name.is_a?(String)
+        errors << "#{entry_prefix}: must be a String (got #{name.class})"
+        next
+      end
+
+      unless name.match?(NAME_RE)
+        errors << "#{entry_prefix}: #{name.inspect} is not a valid env var name"
+      end
+    end
+
+    errors
+  end
+end

--- a/db/migrate/20260517000001_add_env_to_languages.rb
+++ b/db/migrate/20260517000001_add_env_to_languages.rb
@@ -1,0 +1,5 @@
+class AddEnvToLanguages < ActiveRecord::Migration[5.2]
+  def change
+    add_column :languages, :env, :text
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,12 +1,16 @@
 require_relative 'languages/archived'
 require_relative 'languages/active'
 require_relative 'languages/asset_validator'
+require_relative 'languages/env_validator'
 
-# Phase 3 schema check — fail-fast on malformed `assets:` declarations.
-# Per docs/superpowers/specs/2026-05-05-submission-assets-design.md.
-asset_errors = @languages.flat_map { |lang| AssetValidator.validate_language(lang) }
-if asset_errors.any?
-  raise "active.rb asset validation failed:\n  " + asset_errors.join("\n  ")
+# Schema check — fail-fast on malformed `assets:` (Phase 3) or `env:`
+# declarations. Both validators are pure-Ruby and run in CI too via
+# bin/lint-active-rb.
+schema_errors = @languages.flat_map do |lang|
+  AssetValidator.validate_language(lang) + EnvValidator.validate_language(lang)
+end
+if schema_errors.any?
+  raise "active.rb validation failed:\n  " + schema_errors.join("\n  ")
 end
 
 ActiveRecord::Base.transaction do
@@ -20,6 +24,7 @@ ActiveRecord::Base.transaction do
       compile_cmd: language[:compile_cmd],
       run_cmd: language[:run_cmd],
       assets: language[:assets],
+      env: language[:env],
     )
   end
 end

--- a/spec/db/languages/env_validator_spec.rb
+++ b/spec/db/languages/env_validator_spec.rb
@@ -1,0 +1,91 @@
+require "rails_helper"
+require_relative "../../../db/languages/env_validator"
+
+RSpec.describe EnvValidator do
+  describe ".validate_language" do
+    let(:lang) { { id: 9999, name: "Test Lang" } }
+
+    it "passes when no :env key is present" do
+      errors = described_class.validate_language(lang)
+      expect(errors).to be_empty
+    end
+
+    it "passes when :env is an empty array" do
+      lang[:env] = []
+      errors = described_class.validate_language(lang)
+      expect(errors).to be_empty
+    end
+
+    it "passes for all-uppercase POSIX-style names" do
+      lang[:env] = %w[DOTNET_NOLOGO DOTNET_CLI_TELEMETRY_OPTOUT]
+      errors = described_class.validate_language(lang)
+      expect(errors).to be_empty
+    end
+
+    it "passes for mixed-case names (.NET canonical form)" do
+      lang[:env] = %w[DOTNET_EnableWriteXorExecute]
+      errors = described_class.validate_language(lang)
+      expect(errors).to be_empty
+    end
+
+    it "passes for names with leading underscore" do
+      lang[:env] = %w[_DEBUG]
+      errors = described_class.validate_language(lang)
+      expect(errors).to be_empty
+    end
+
+    it "errors when :env is not an Array" do
+      lang[:env] = "DOTNET_NOLOGO"
+      errors = described_class.validate_language(lang)
+      expect(errors).to include(a_string_including("must be an Array"))
+    end
+
+    it "errors when :env is a Hash" do
+      lang[:env] = { "FOO" => "bar" }
+      errors = described_class.validate_language(lang)
+      expect(errors).to include(a_string_including("must be an Array"))
+    end
+
+    it "errors when an entry is not a String" do
+      lang[:env] = [123]
+      errors = described_class.validate_language(lang)
+      expect(errors).to include(a_string_including("must be a String"))
+    end
+
+    it "errors when an entry starts with a digit" do
+      lang[:env] = %w[1_INVALID]
+      errors = described_class.validate_language(lang)
+      expect(errors).to include(a_string_including("not a valid env var name"))
+    end
+
+    it "errors when an entry contains '=' (value form not allowed)" do
+      lang[:env] = ["DOTNET_NOLOGO=1"]
+      errors = described_class.validate_language(lang)
+      expect(errors).to include(a_string_including("not a valid env var name"))
+    end
+
+    it "errors when an entry contains a space" do
+      lang[:env] = ["DOTNET NOLOGO"]
+      errors = described_class.validate_language(lang)
+      expect(errors).to include(a_string_including("not a valid env var name"))
+    end
+
+    it "errors when an entry contains a hyphen" do
+      lang[:env] = %w[DOTNET-NOLOGO]
+      errors = described_class.validate_language(lang)
+      expect(errors).to include(a_string_including("not a valid env var name"))
+    end
+
+    it "errors when an entry is an empty string" do
+      lang[:env] = [""]
+      errors = described_class.validate_language(lang)
+      expect(errors).to include(a_string_including("not a valid env var name"))
+    end
+
+    it "reports errors for each bad entry" do
+      lang[:env] = %w[GOOD 1_BAD ALSO-BAD]
+      errors = described_class.validate_language(lang)
+      expect(errors.size).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `-E DOTNET_EnableWriteXorExecute` lines in `IsolateJob` (compile + run) with a per-language `env:` array on each `active.rb` record. Mirrors the Phase 3 `assets:` pattern: pure-Ruby validator, two-layer enforcement (seed-time + `bin/lint-active-rb` CI gate), no Rails internals in the validator.
- Adds `env:` to ids 3007 (.NET 7) and 3008 (.NET 8) — `DOTNET_EnableWriteXorExecute`, `DOTNET_NOLOGO`, `DOTNET_CLI_TELEMETRY_OPTOUT`. Mono (3006) is no longer carried along for the .NET-specific flag; .NET lanes additionally pick up first-build latency and outbound-telemetry suppression that previously weren't propagated.
- Closes #33.

## Design notes

- **`env:` declares NAMES only**, not `NAME=value`. Values are sourced from the compiler image's Tier 12 ENV (`DOTNET_EnableWriteXorExecute=0` etc. in `NewtonDockerfile-v2`); `IsolateJob#language_env_flags` emits `-E NAME` flags that re-expose those values across isolate's env-stripping. Validator rejects `=` in names.
- **Regex is case-permissive** (`[A-Za-z_][A-Za-z0-9_]*`) rather than the issue's literal `[A-Z][A-Z0-9_]*`, because Microsoft's canonical .NET names (e.g. `DOTNET_EnableWriteXorExecute`) are not all-uppercase. POSIX allows mixed case.
- **`DOTNET_SKIP_FIRST_TIME_EXPERIENCE` / `DOTNET_MULTILEVEL_LOOKUP` deliberately omitted** — both are no-ops on .NET 7+, per the table in #33.
- **No image tag bump** in this PR. The mechanism is wired up but `0.76` remains the published tag; the deploy that picks this up will bump.
- **No new IsolateJob spec.** The existing `spec/jobs/isolate_job_spec.rb` is empty/upstream and the parallel `assets:` work didn't touch it either — coverage for the new code path lives in `EnvValidator` spec, paralleling `AssetValidator` spec.

## Files

| File | Purpose |
|---|---|
| `db/migrate/20260517000001_add_env_to_languages.rb` | `text :env` column on `languages` (mirrors `AddAssetsToLanguages`) |
| `app/models/language.rb` | `serialize :env` |
| `db/languages/env_validator.rb` | Pure-Ruby validator, mirrors `AssetValidator` |
| `db/seeds.rb` | Runs env validation in the fail-fast block; passes `env:` to `Language.create` |
| `app/jobs/isolate_job.rb` | New `language_env_flags` helper; replaces both hardcoded `-E DOTNET_*` lines |
| `db/languages/active.rb` | 3007/3008 declare `env:`; 3006 unchanged |
| `bin/lint-active-rb` | Calls `EnvValidator` alongside `AssetValidator` |
| `spec/db/languages/env_validator_spec.rb` | Mirrors `asset_validator_spec.rb` |
| `CLAUDE.md` | `.NET` paragraph rewritten; new "Per-language env propagation" bullet |

## Test plan

- [x] `ruby bin/lint-active-rb` → `OK — 25 languages, 1 asset declarations, 6 env declarations validated.`
- [x] Adversarial smoke of `EnvValidator` (Array enforcement, `=`-rejection, non-String entries, leading digit, hyphen)
- [ ] `bundle exec rspec spec/db/languages/env_validator_spec.rb` once CI picks it up
- [ ] Smoke `bin/newton-smoke-test` against a rebuilt image — expected 28/0/0 on amd64, 26/0/2 on arm64 (same as 0.76 baseline; this PR doesn't change observable behavior on .NET lanes, only how the `-E` flags get there)
- [ ] On the deploy that picks this up: confirm 3006 (Mono) compile/run isolate command lines no longer contain `-E DOTNET_EnableWriteXorExecute`; confirm 3007/3008 lines now also carry `-E DOTNET_NOLOGO -E DOTNET_CLI_TELEMETRY_OPTOUT`

🤖 Generated with [Claude Code](https://claude.com/claude-code)