### PR TITLE
[NS-13252] Judge0: bearer auth + per-user rate limit on submissions (code)

### DIFF
--- a/app/controllers/concerns/submission_authentication.rb
+++ b/app/controllers/concerns/submission_authentication.rb
@@ -14,7 +14,8 @@ module SubmissionAuthentication
         @token_validator ||= CachingTokenValidator.new(
           NewtonTokenValidator.new(Rails.application.secrets.judge0_auth_validate_url),
           ttl_seconds: Rails.application.secrets.auth_cache_ttl_seconds.to_i,
-          negative_ttl_seconds: 5
+          negative_ttl_seconds: 5,
+          max_entries: Rails.application.secrets.auth_cache_max_entries.to_i
         )
       end
     end
@@ -40,17 +41,17 @@ module SubmissionAuthentication
       return
     end
 
-    result =
+    validation_result =
       begin
         SubmissionAuthentication.token_validator.validate(token)
       rescue NewtonTokenValidator::TransientError
         return render_auth_error(503, "Auth temporarily unavailable")
       end
 
-    return render_auth_error(403, "Invalid token") if result == :invalid
+    return render_auth_error(403, "Invalid token") if validation_result == :invalid
 
     @is_service_caller = false
-    @current_user_id = result
+    @current_user_id = validation_result
   end
 
   def enforce_submission_rate_limit
@@ -67,15 +68,15 @@ module SubmissionAuthentication
   end
 
   def bearer_token
-    header = request.headers["Authorization"].to_s.strip
-    return nil unless header.downcase.start_with?("bearer ")
-    header[7..-1].to_s.strip
+    auth_header = request.headers["Authorization"].to_s.strip
+    return nil unless auth_header.downcase.start_with?("bearer ")
+    auth_header[7..-1].to_s.strip
   end
 
   def service_token?(token)
-    secret = Rails.application.secrets.submission_service_token.to_s
-    return false if secret.empty?
-    ActiveSupport::SecurityUtils.secure_compare(token, secret)
+    service_secret = Rails.application.secrets.submission_service_token.to_s
+    return false if service_secret.empty?
+    ActiveSupport::SecurityUtils.secure_compare(token, service_secret)
   end
 
   def render_auth_error(status, message)

--- a/app/controllers/concerns/submission_authentication.rb
+++ b/app/controllers/concerns/submission_authentication.rb
@@ -39,7 +39,7 @@ module SubmissionAuthentication
     if token.nil? || token.empty?
       @is_service_caller = false
       @is_anonymous = true
-      @client_ip = normalized_ip(request.remote_ip)
+      @client_ip = normalized_ip(client_ip)
       return
     end
 
@@ -87,7 +87,12 @@ module SubmissionAuthentication
     return if @is_service_caller
 
     begin
-      key = "r:#{normalized_ip(request.remote_ip)}"
+      if @is_anonymous
+        key = "r:#{@client_ip}"
+      else
+        return if @current_user_id.nil?
+        key = "r:u:#{@current_user_id}"
+      end
       limit = Rails.application.secrets.read_rate_limit_per_minute.to_i
       unless SubmissionAuthentication.rate_limiter.allow?(key, limit)
         render json: { error: "Rate limit exceeded" }, status: 429
@@ -102,6 +107,11 @@ module SubmissionAuthentication
     auth_header = request.headers["Authorization"].to_s.strip
     return nil unless auth_header.downcase.start_with?("bearer ")
     auth_header[7..-1].to_s.strip
+  end
+
+  def client_ip
+    forwarded = request.headers["X-Forwarded-For"].to_s.split(",").map(&:strip).reject(&:empty?)
+    forwarded.last || request.remote_ip
   end
 
   # Group IPv6 by /64 (matches pyro's client_ip normalization); IPv4 stays exact.

--- a/app/controllers/concerns/submission_authentication.rb
+++ b/app/controllers/concerns/submission_authentication.rb
@@ -2,7 +2,7 @@ require 'active_support/security_utils'
 require 'ipaddr'
 
 # Submission auth + rate limit (NS-13252): service secret bypasses; valid token -> per-user id,
-# no token -> anonymous per-IP; reads are IP-limited. Auth fails closed on invalid token; limiting fails open.
+# no token -> anonymous per-IP; reads are IP-limited. Auth and the limiter both fail closed (limiter error -> 503).
 module SubmissionAuthentication
   extend ActiveSupport::Concern
 
@@ -76,7 +76,8 @@ module SubmissionAuthentication
         render json: { error: "Rate limit exceeded" }, status: 429
       end
     rescue StandardError
-      # Fail open: a Redis blip (or limiter build failure) must not block submissions.
+      # Fail closed: a limiter/Redis failure returns a generic 503, not free passage.
+      render json: { error: "Service temporarily unavailable" }, status: 503
     end
   end
 
@@ -90,7 +91,8 @@ module SubmissionAuthentication
         render json: { error: "Rate limit exceeded" }, status: 429
       end
     rescue StandardError
-      # Fail open.
+      # Fail closed: a limiter/Redis failure returns a generic 503, not free passage.
+      render json: { error: "Service temporarily unavailable" }, status: 503
     end
   end
 

--- a/app/controllers/concerns/submission_authentication.rb
+++ b/app/controllers/concerns/submission_authentication.rb
@@ -14,7 +14,7 @@ module SubmissionAuthentication
       @token_validator || SINGLETON_MUTEX.synchronize do
         @token_validator ||= CachingTokenValidator.new(
           NewtonTokenValidator.new(Rails.application.secrets.judge0_auth_validate_url),
-          ttl_seconds: Rails.application.secrets.auth_cache_ttl_seconds.to_i,
+          ttl_seconds: Rails.application.secrets.auth_positive_cache_ttl_seconds.to_i,
           negative_ttl_seconds: Rails.application.secrets.auth_negative_cache_ttl_seconds.to_i,
           max_entries: Rails.application.secrets.auth_cache_max_entries.to_i
         )

--- a/app/controllers/concerns/submission_authentication.rb
+++ b/app/controllers/concerns/submission_authentication.rb
@@ -1,0 +1,84 @@
+require 'active_support/security_utils'
+
+# Submission auth + per-user rate limit (NS-13252): service secret bypasses the
+# limit, other tokens validate against newton-api. Auth fails closed; limiting fails open.
+module SubmissionAuthentication
+  extend ActiveSupport::Concern
+
+  # Process-wide singletons so the cache/Redis persist across requests (controller is per-request).
+  SINGLETON_MUTEX = Mutex.new
+
+  class << self
+    def token_validator
+      @token_validator || SINGLETON_MUTEX.synchronize do
+        @token_validator ||= CachingTokenValidator.new(
+          NewtonTokenValidator.new(Rails.application.secrets.judge0_auth_validate_url),
+          ttl_seconds: Rails.application.secrets.auth_cache_ttl_seconds.to_i,
+          negative_ttl_seconds: 5
+        )
+      end
+    end
+
+    def rate_limiter
+      @rate_limiter || SINGLETON_MUTEX.synchronize do
+        @rate_limiter ||= SubmissionRateLimiter.new(
+          Rails.application.secrets.rate_limit_redis_url,
+          Rails.application.secrets.submission_rate_limit_per_minute
+        )
+      end
+    end
+  end
+
+  private
+
+  def authenticate_submission_request
+    token = bearer_token
+    return render_auth_error(401, "Unauthorized") if token.nil? || token.empty?
+
+    if service_token?(token)
+      @is_service_caller = true
+      return
+    end
+
+    result =
+      begin
+        SubmissionAuthentication.token_validator.validate(token)
+      rescue NewtonTokenValidator::TransientError
+        return render_auth_error(503, "Auth temporarily unavailable")
+      end
+
+    return render_auth_error(403, "Invalid token") if result == :invalid
+
+    @is_service_caller = false
+    @current_user_id = result
+  end
+
+  def enforce_submission_rate_limit
+    return if @is_service_caller
+    return if @current_user_id.nil?
+
+    begin
+      unless SubmissionAuthentication.rate_limiter.allow?(@current_user_id)
+        render json: { error: "Rate limit exceeded" }, status: 429
+      end
+    rescue StandardError
+      # Fail open: a Redis blip (or limiter build failure) must not block submissions.
+    end
+  end
+
+  def bearer_token
+    header = request.headers["Authorization"].to_s.strip
+    return nil unless header.downcase.start_with?("bearer ")
+    header[7..-1].to_s.strip
+  end
+
+  def service_token?(token)
+    secret = Rails.application.secrets.submission_service_token.to_s
+    return false if secret.empty?
+    ActiveSupport::SecurityUtils.secure_compare(token, secret)
+  end
+
+  def render_auth_error(status, message)
+    render json: { error: message }, status: status
+  end
+end

--- a/app/controllers/concerns/submission_authentication.rb
+++ b/app/controllers/concerns/submission_authentication.rb
@@ -15,7 +15,7 @@ module SubmissionAuthentication
         @token_validator ||= CachingTokenValidator.new(
           NewtonTokenValidator.new(Rails.application.secrets.judge0_auth_validate_url),
           ttl_seconds: Rails.application.secrets.auth_cache_ttl_seconds.to_i,
-          negative_ttl_seconds: 5,
+          negative_ttl_seconds: Rails.application.secrets.auth_negative_cache_ttl_seconds.to_i,
           max_entries: Rails.application.secrets.auth_cache_max_entries.to_i
         )
       end
@@ -24,7 +24,9 @@ module SubmissionAuthentication
     def rate_limiter
       @rate_limiter || SINGLETON_MUTEX.synchronize do
         @rate_limiter ||= SubmissionRateLimiter.new(
-          Rails.application.secrets.rate_limit_redis_url
+          host: ENV["REDIS_HOST"],
+          port: ENV["REDIS_PORT"],
+          password: ENV["REDIS_PASSWORD"]
         )
       end
     end

--- a/app/controllers/concerns/submission_authentication.rb
+++ b/app/controllers/concerns/submission_authentication.rb
@@ -1,7 +1,8 @@
 require 'active_support/security_utils'
+require 'ipaddr'
 
-# Submission auth + per-user rate limit (NS-13252): service secret bypasses the
-# limit, other tokens validate against newton-api. Auth fails closed; limiting fails open.
+# Submission auth + rate limit (NS-13252): service secret bypasses; valid token -> per-user id,
+# no token -> anonymous per-IP; reads are IP-limited. Auth fails closed on invalid token; limiting fails open.
 module SubmissionAuthentication
   extend ActiveSupport::Concern
 
@@ -36,7 +37,7 @@ module SubmissionAuthentication
     if token.nil? || token.empty?
       @is_service_caller = false
       @is_anonymous = true
-      @client_ip = request.remote_ip
+      @client_ip = normalized_ip(request.remote_ip)
       return
     end
 
@@ -83,7 +84,7 @@ module SubmissionAuthentication
     return if @is_service_caller
 
     begin
-      key = "r:#{request.remote_ip}"
+      key = "r:#{normalized_ip(request.remote_ip)}"
       limit = Rails.application.secrets.read_rate_limit_per_minute.to_i
       unless SubmissionAuthentication.rate_limiter.allow?(key, limit)
         render json: { error: "Rate limit exceeded" }, status: 429
@@ -97,6 +98,14 @@ module SubmissionAuthentication
     auth_header = request.headers["Authorization"].to_s.strip
     return nil unless auth_header.downcase.start_with?("bearer ")
     auth_header[7..-1].to_s.strip
+  end
+
+  # Group IPv6 by /64 (matches pyro's client_ip normalization); IPv4 stays exact.
+  def normalized_ip(ip)
+    addr = IPAddr.new(ip.to_s)
+    addr.ipv6? ? "#{addr.mask(64)}/64" : ip.to_s
+  rescue IPAddr::InvalidAddressError
+    ip.to_s
   end
 
   def service_token?(token)

--- a/app/controllers/concerns/submission_authentication.rb
+++ b/app/controllers/concerns/submission_authentication.rb
@@ -36,16 +36,26 @@ module SubmissionAuthentication
 
   def authenticate_submission_request
     token = bearer_token
+    @client_ip = normalized_ip(client_ip)
+
     if token.nil? || token.empty?
       @is_service_caller = false
       @is_anonymous = true
-      @client_ip = normalized_ip(client_ip)
       return
     end
 
     if service_token?(token)
       @is_service_caller = true
       return
+    end
+
+    unless SubmissionAuthentication.token_validator.cached?(token)
+      begin
+        limit = Rails.application.secrets.anon_submission_rate_limit_per_minute.to_i
+        return render_auth_error(503, "Auth temporarily unavailable") unless SubmissionAuthentication.rate_limiter.allow?("auth:#{@client_ip}", limit)
+      rescue StandardError
+        return render_auth_error(503, "Auth temporarily unavailable")
+      end
     end
 
     validation_result =
@@ -74,7 +84,7 @@ module SubmissionAuthentication
         key = "u:#{@current_user_id}"
         limit = Rails.application.secrets.submission_rate_limit_per_minute.to_i
       end
-      unless SubmissionAuthentication.rate_limiter.allow?(key, limit)
+      unless SubmissionAuthentication.rate_limiter.allow?(key, limit, submission_cost)
         render json: { error: "Rate limit exceeded" }, status: 429
       end
     rescue StandardError
@@ -109,6 +119,11 @@ module SubmissionAuthentication
     auth_header[7..-1].to_s.strip
   end
 
+  def submission_cost
+    size = params[:submissions].respond_to?(:size) ? params[:submissions].size : 1
+    [[size, 1].max, Config::MAX_SUBMISSION_BATCH_SIZE].min
+  end
+
   def client_ip
     forwarded = request.headers["X-Forwarded-For"].to_s.split(",").map(&:strip).reject(&:empty?)
     forwarded.last || request.remote_ip
@@ -117,7 +132,8 @@ module SubmissionAuthentication
   # Group IPv6 by /64 (matches pyro's client_ip normalization); IPv4 stays exact.
   def normalized_ip(ip)
     addr = IPAddr.new(ip.to_s)
-    addr.ipv6? ? "#{addr.mask(64)}/64" : ip.to_s
+    addr = addr.native if addr.ipv4_mapped?
+    addr.ipv6? ? "#{addr.mask(64)}/64" : addr.to_s
   rescue IPAddr::InvalidAddressError
     ip.to_s
   end

--- a/app/controllers/concerns/submission_authentication.rb
+++ b/app/controllers/concerns/submission_authentication.rb
@@ -23,8 +23,7 @@ module SubmissionAuthentication
     def rate_limiter
       @rate_limiter || SINGLETON_MUTEX.synchronize do
         @rate_limiter ||= SubmissionRateLimiter.new(
-          Rails.application.secrets.rate_limit_redis_url,
-          Rails.application.secrets.submission_rate_limit_per_minute
+          Rails.application.secrets.rate_limit_redis_url
         )
       end
     end
@@ -34,7 +33,12 @@ module SubmissionAuthentication
 
   def authenticate_submission_request
     token = bearer_token
-    return render_auth_error(401, "Unauthorized") if token.nil? || token.empty?
+    if token.nil? || token.empty?
+      @is_service_caller = false
+      @is_anonymous = true
+      @client_ip = request.remote_ip
+      return
+    end
 
     if service_token?(token)
       @is_service_caller = true
@@ -51,19 +55,41 @@ module SubmissionAuthentication
     return render_auth_error(403, "Invalid token") if validation_result == :invalid
 
     @is_service_caller = false
+    @is_anonymous = false
     @current_user_id = validation_result
   end
 
   def enforce_submission_rate_limit
     return if @is_service_caller
-    return if @current_user_id.nil?
 
     begin
-      unless SubmissionAuthentication.rate_limiter.allow?(@current_user_id)
+      if @is_anonymous
+        key = "ip:#{@client_ip}"
+        limit = Rails.application.secrets.anon_submission_rate_limit_per_minute.to_i
+      else
+        return if @current_user_id.nil?
+        key = "u:#{@current_user_id}"
+        limit = Rails.application.secrets.submission_rate_limit_per_minute.to_i
+      end
+      unless SubmissionAuthentication.rate_limiter.allow?(key, limit)
         render json: { error: "Rate limit exceeded" }, status: 429
       end
     rescue StandardError
       # Fail open: a Redis blip (or limiter build failure) must not block submissions.
+    end
+  end
+
+  def enforce_read_rate_limit
+    return if @is_service_caller
+
+    begin
+      key = "r:#{request.remote_ip}"
+      limit = Rails.application.secrets.read_rate_limit_per_minute.to_i
+      unless SubmissionAuthentication.rate_limiter.allow?(key, limit)
+        render json: { error: "Rate limit exceeded" }, status: 429
+      end
+    rescue StandardError
+      # Fail open.
     end
   end
 

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -5,6 +5,7 @@ class SubmissionsController < ApplicationController
   # unauthenticated or throttled request is rejected before any queue work.
   before_action :authenticate_submission_request, only: [:create, :batch_create, :show, :batch_show]
   before_action :enforce_submission_rate_limit, only: [:create, :batch_create]
+  before_action :enforce_read_rate_limit, only: [:show, :batch_show]
 
   before_action :authorize_request, only: [:index, :destroy]
   before_action :check_maintenance, only: [:create, :destroy]

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -1,4 +1,11 @@
 class SubmissionsController < ApplicationController
+  include SubmissionAuthentication
+
+  # Auth + per-user rate limit run first, before the check_* filters, so an
+  # unauthenticated or throttled request is rejected before any queue work.
+  before_action :authenticate_submission_request, only: [:create, :batch_create, :show, :batch_show]
+  before_action :enforce_submission_rate_limit, only: [:create, :batch_create]
+
   before_action :authorize_request, only: [:index, :destroy]
   before_action :check_maintenance, only: [:create, :destroy]
   before_action :check_wait, only: [:create] # Wait in batch_create is not allowed

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -1,8 +1,7 @@
 class SubmissionsController < ApplicationController
   include SubmissionAuthentication
 
-  # Auth + per-user rate limit run first, before the check_* filters, so an
-  # unauthenticated or throttled request is rejected before any queue work.
+  # Authenticate, then rate-limit: per-user or per-IP on create/batch_create, per-IP on show/batch_show.
   before_action :authenticate_submission_request, only: [:create, :batch_create, :show, :batch_show]
   before_action :enforce_submission_rate_limit, only: [:create, :batch_create]
   before_action :enforce_read_rate_limit, only: [:show, :batch_show]

--- a/app/services/caching_token_validator.rb
+++ b/app/services/caching_token_validator.rb
@@ -1,12 +1,11 @@
 # In-memory TTL cache: positive/negative results cached (never transient), bounded, thread-safe.
 class CachingTokenValidator
-  MAX_ENTRIES = 50_000
-
-  def initialize(inner, ttl_seconds:, negative_ttl_seconds:,
+  def initialize(inner_validator, ttl_seconds:, negative_ttl_seconds:, max_entries:,
                  clock: -> { Process.clock_gettime(Process::CLOCK_MONOTONIC) })
-    @inner = inner
+    @inner_validator = inner_validator
     @ttl = ttl_seconds.to_i
     @negative_ttl = negative_ttl_seconds.to_i
+    @max_entries = max_entries.to_i
     @clock = clock
     @entries = {}
     @mutex = Mutex.new
@@ -20,12 +19,12 @@ class CachingTokenValidator
       return entry[:value] if entry && now < entry[:expires_at]
     end
 
-    value = @inner.validate(token) # may raise TransientError — intentionally not cached
+    value = @inner_validator.validate(token) # may raise TransientError — intentionally not cached
 
     ttl = value == :invalid ? @negative_ttl : @ttl
     @mutex.synchronize do
-      purge_expired(now) if @entries.size >= MAX_ENTRIES
-      @entries[token] = { value: value, expires_at: now + ttl } if @entries.size < MAX_ENTRIES
+      purge_expired(now) if @entries.size >= @max_entries
+      @entries[token] = { value: value, expires_at: now + ttl } if @entries.size < @max_entries
     end
     value
   end

--- a/app/services/caching_token_validator.rb
+++ b/app/services/caching_token_validator.rb
@@ -1,0 +1,38 @@
+# In-memory TTL cache: positive/negative results cached (never transient), bounded, thread-safe.
+class CachingTokenValidator
+  MAX_ENTRIES = 50_000
+
+  def initialize(inner, ttl_seconds:, negative_ttl_seconds:,
+                 clock: -> { Process.clock_gettime(Process::CLOCK_MONOTONIC) })
+    @inner = inner
+    @ttl = ttl_seconds.to_i
+    @negative_ttl = negative_ttl_seconds.to_i
+    @clock = clock
+    @entries = {}
+    @mutex = Mutex.new
+  end
+
+  # Returns a user id String or :invalid; raises on transient (not cached).
+  def validate(token)
+    now = @clock.call
+    @mutex.synchronize do
+      entry = @entries[token]
+      return entry[:value] if entry && now < entry[:expires_at]
+    end
+
+    value = @inner.validate(token) # may raise TransientError — intentionally not cached
+
+    ttl = value == :invalid ? @negative_ttl : @ttl
+    @mutex.synchronize do
+      purge_expired(now) if @entries.size >= MAX_ENTRIES
+      @entries[token] = { value: value, expires_at: now + ttl } if @entries.size < MAX_ENTRIES
+    end
+    value
+  end
+
+  private
+
+  def purge_expired(now)
+    @entries.delete_if { |_token, entry| now >= entry[:expires_at] }
+  end
+end

--- a/app/services/caching_token_validator.rb
+++ b/app/services/caching_token_validator.rb
@@ -7,7 +7,8 @@ class CachingTokenValidator
     @negative_ttl = negative_ttl_seconds.to_i
     @max_entries = max_entries.to_i
     @clock = clock
-    @entries = {}
+    @positive = {}
+    @negative = {}
     @mutex = Mutex.new
   end
 
@@ -15,23 +16,42 @@ class CachingTokenValidator
   def validate(token)
     now = @clock.call
     @mutex.synchronize do
-      entry = @entries[token]
+      entry = @positive[token] || @negative[token]
       return entry[:value] if entry && now < entry[:expires_at]
     end
 
     value = @inner_validator.validate(token) # may raise TransientError — intentionally not cached
 
-    ttl = value == :invalid ? @negative_ttl : @ttl
-    @mutex.synchronize do
-      purge_expired(now) if @entries.size >= @max_entries
-      @entries[token] = { value: value, expires_at: now + ttl } if @entries.size < @max_entries
-    end
+    store(now, token, value)
     value
   end
 
   private
 
+  def store(now, token, value)
+    if value == :invalid
+      cache, ttl = @negative, @negative_ttl
+    else
+      cache, ttl = @positive, @ttl
+    end
+
+    @mutex.synchronize do
+      @positive.delete(token)
+      @negative.delete(token)
+      purge_expired(now)
+      return if @positive.size + @negative.size >= @max_entries
+
+      cache[token] = { value: value, expires_at: now + ttl }
+    end
+  end
+
   def purge_expired(now)
-    @entries.delete_if { |_token, entry| now >= entry[:expires_at] }
+    [@positive, @negative].each do |cache|
+      while (pair = cache.first)
+        break if now < pair[1][:expires_at]
+
+        cache.shift
+      end
+    end
   end
 end

--- a/app/services/caching_token_validator.rb
+++ b/app/services/caching_token_validator.rb
@@ -26,6 +26,14 @@ class CachingTokenValidator
     value
   end
 
+  def cached?(token)
+    now = @clock.call
+    @mutex.synchronize do
+      entry = @positive[token] || @negative[token]
+      !entry.nil? && now < entry[:expires_at]
+    end
+  end
+
   private
 
   def store(now, token, value)

--- a/app/services/caching_token_validator.rb
+++ b/app/services/caching_token_validator.rb
@@ -1,3 +1,5 @@
+require "digest"
+
 # In-memory TTL cache: positive/negative results cached (never transient), bounded, thread-safe.
 class CachingTokenValidator
   def initialize(inner_validator, ttl_seconds:, negative_ttl_seconds:, max_entries:,
@@ -15,28 +17,34 @@ class CachingTokenValidator
   # Returns a user id String or :invalid; raises on transient (not cached).
   def validate(token)
     now = @clock.call
+    key = digest(token)
     @mutex.synchronize do
-      entry = @positive[token] || @negative[token]
+      entry = @positive[key] || @negative[key]
       return entry[:value] if entry && now < entry[:expires_at]
     end
 
     value = @inner_validator.validate(token) # may raise TransientError — intentionally not cached
 
-    store(now, token, value)
+    store(now, key, value)
     value
   end
 
   def cached?(token)
     now = @clock.call
+    key = digest(token)
     @mutex.synchronize do
-      entry = @positive[token] || @negative[token]
+      entry = @positive[key] || @negative[key]
       !entry.nil? && now < entry[:expires_at]
     end
   end
 
   private
 
-  def store(now, token, value)
+  def digest(token)
+    Digest::SHA256.hexdigest(token)
+  end
+
+  def store(now, key, value)
     if value == :invalid
       cache, ttl = @negative, @negative_ttl
     else
@@ -44,12 +52,12 @@ class CachingTokenValidator
     end
 
     @mutex.synchronize do
-      @positive.delete(token)
-      @negative.delete(token)
+      @positive.delete(key)
+      @negative.delete(key)
       evict_one_expired(now) if @positive.size + @negative.size >= @max_entries
       return if @positive.size + @negative.size >= @max_entries
 
-      cache[token] = { value: value, expires_at: now + ttl }
+      cache[key] = { value: value, expires_at: now + ttl }
     end
   end
 

--- a/app/services/caching_token_validator.rb
+++ b/app/services/caching_token_validator.rb
@@ -38,20 +38,20 @@ class CachingTokenValidator
     @mutex.synchronize do
       @positive.delete(token)
       @negative.delete(token)
-      purge_expired(now)
+      evict_one_expired(now) if @positive.size + @negative.size >= @max_entries
       return if @positive.size + @negative.size >= @max_entries
 
       cache[token] = { value: value, expires_at: now + ttl }
     end
   end
 
-  def purge_expired(now)
+  def evict_one_expired(now)
     [@positive, @negative].each do |cache|
-      while (pair = cache.first)
-        break if now < pair[1][:expires_at]
+      pair = cache.first
+      next unless pair && now >= pair[1][:expires_at]
 
-        cache.shift
-      end
+      cache.shift
+      return
     end
   end
 end

--- a/app/services/newton_token_validator.rb
+++ b/app/services/newton_token_validator.rb
@@ -1,0 +1,40 @@
+require 'net/http'
+require 'json'
+require 'uri'
+
+# Validates a Bearer token via the newton-api endpoint (Judge0 holds no secret of its own).
+class NewtonTokenValidator
+  class TransientError < StandardError; end
+
+  def initialize(validate_url)
+    @validate_url = validate_url
+  end
+
+  # Returns user id, :invalid (401/403), or raises TransientError (caller fails closed).
+  def validate(token)
+    uri = URI.parse(@validate_url)
+    req = Net::HTTP::Get.new(uri)
+    req["Authorization"] = "Bearer #{token}"
+
+    resp = Net::HTTP.start(
+      uri.host, uri.port,
+      use_ssl: uri.scheme == "https", open_timeout: 3, read_timeout: 3
+    ) { |http| http.request(req) }
+
+    case resp.code.to_i
+    when 200
+      user_id = JSON.parse(resp.body)["user_id"]
+      raise TransientError, "empty user_id" if user_id.nil? || user_id.to_s.empty?
+      user_id.to_s
+    when 401, 403
+      :invalid
+    else
+      raise TransientError, "unexpected status #{resp.code}"
+    end
+  rescue TransientError
+    raise
+  rescue StandardError => e
+    # Any network/TLS/parse failure is transient → fail closed (503), never a 500.
+    raise TransientError, e.message
+  end
+end

--- a/app/services/newton_token_validator.rb
+++ b/app/services/newton_token_validator.rb
@@ -13,28 +13,28 @@ class NewtonTokenValidator
   # Returns user id, :invalid (401/403), or raises TransientError (caller fails closed).
   def validate(token)
     uri = URI.parse(@validate_url)
-    req = Net::HTTP::Get.new(uri)
-    req["Authorization"] = "Bearer #{token}"
+    request = Net::HTTP::Get.new(uri)
+    request["Authorization"] = "Bearer #{token}"
 
-    resp = Net::HTTP.start(
+    response = Net::HTTP.start(
       uri.host, uri.port,
       use_ssl: uri.scheme == "https", open_timeout: 3, read_timeout: 3
-    ) { |http| http.request(req) }
+    ) { |http| http.request(request) }
 
-    case resp.code.to_i
+    case response.code.to_i
     when 200
-      user_id = JSON.parse(resp.body)["user_id"]
+      user_id = JSON.parse(response.body)["user_id"]
       raise TransientError, "empty user_id" if user_id.nil? || user_id.to_s.empty?
       user_id.to_s
     when 401, 403
       :invalid
     else
-      raise TransientError, "unexpected status #{resp.code}"
+      raise TransientError, "unexpected status #{response.code}"
     end
   rescue TransientError
     raise
-  rescue StandardError => e
+  rescue StandardError => error
     # Any network/TLS/parse failure is transient → fail closed (503), never a 500.
-    raise TransientError, e.message
+    raise TransientError, error.message
   end
 end

--- a/app/services/submission_rate_limiter.rb
+++ b/app/services/submission_rate_limiter.rb
@@ -8,11 +8,11 @@ class SubmissionRateLimiter
   end
 
   # true if the key is within the given one-minute budget; raises on Redis error.
-  def allow?(key, limit)
+  def allow?(key, limit, amount = 1)
     window = @clock.call / 60
     redis_key = "judge0:rl:#{key}:#{window}"
-    count = @redis.incr(redis_key)
-    @redis.expire(redis_key, 70) if count == 1
+    count = amount == 1 ? @redis.incr(redis_key) : @redis.incrby(redis_key, amount)
+    @redis.expire(redis_key, 70) if count == amount
     count <= limit.to_i
   end
 end

--- a/app/services/submission_rate_limiter.rb
+++ b/app/services/submission_rate_limiter.rb
@@ -1,19 +1,18 @@
 require 'redis'
 
-# Redis fixed-window per-user limiter, global across pods; raises on Redis error (caller fails open).
+# Redis fixed-window per-minute limiter, global across pods; raises on Redis error (caller fails open).
 class SubmissionRateLimiter
-  def initialize(redis_url, per_minute_limit, clock: -> { Time.now.to_i })
+  def initialize(redis_url, clock: -> { Time.now.to_i })
     @redis = Redis.new(url: redis_url)
-    @limit = per_minute_limit.to_i
     @clock = clock
   end
 
-  # true if the key is within its one-minute budget; raises on Redis error (caller fails open).
-  def allow?(key)
+  # true if the key is within the given one-minute budget; raises on Redis error (caller fails open).
+  def allow?(key, limit)
     window = @clock.call / 60
     redis_key = "judge0:rl:#{key}:#{window}"
     count = @redis.incr(redis_key)
     @redis.expire(redis_key, 70) if count == 1
-    count <= @limit
+    count <= limit.to_i
   end
 end

--- a/app/services/submission_rate_limiter.rb
+++ b/app/services/submission_rate_limiter.rb
@@ -1,0 +1,19 @@
+require 'redis'
+
+# Redis fixed-window per-user limiter, global across pods; raises on Redis error (caller fails open).
+class SubmissionRateLimiter
+  def initialize(redis_url, per_minute_limit, clock: -> { Time.now.to_i })
+    @redis = Redis.new(url: redis_url)
+    @limit = per_minute_limit.to_i
+    @clock = clock
+  end
+
+  # true if the key is within its one-minute budget; raises on Redis error (caller fails open).
+  def allow?(key)
+    window = @clock.call / 60
+    redis_key = "judge0:rl:#{key}:#{window}"
+    count = @redis.incr(redis_key)
+    @redis.expire(redis_key, 70) if count == 1
+    count <= @limit
+  end
+end

--- a/app/services/submission_rate_limiter.rb
+++ b/app/services/submission_rate_limiter.rb
@@ -1,13 +1,13 @@
 require 'redis'
 
-# Redis fixed-window per-minute limiter, global across pods; raises on Redis error (caller fails open).
+# Redis fixed-window per-minute limiter, global across pods; raises on Redis error.
 class SubmissionRateLimiter
-  def initialize(redis_url, clock: -> { Time.now.to_i })
-    @redis = Redis.new(url: redis_url)
+  def initialize(host:, port:, password:, clock: -> { Time.now.to_i })
+    @redis = Redis.new(host: host, port: port, password: password)
     @clock = clock
   end
 
-  # true if the key is within the given one-minute budget; raises on Redis error (caller fails open).
+  # true if the key is within the given one-minute budget; raises on Redis error.
   def allow?(key, limit)
     window = @clock.call / 60
     redis_key = "judge0:rl:#{key}:#{window}"

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -6,11 +6,11 @@ default: &default
   submission_service_token: <%= ENV["JUDGE0_SUBMISSION_SERVICE_TOKEN"].to_s.strip %>
   judge0_auth_validate_url: <%= ENV["JUDGE0_AUTH_VALIDATE_URL"] %>
   submission_rate_limit_per_minute: <%= ENV.fetch("JUDGE0_SUBMISSION_RATE_LIMIT_PER_MINUTE", "60") %>
-  anon_submission_rate_limit_per_minute: <%= ENV.fetch("JUDGE0_ANON_SUBMISSION_RATE_LIMIT_PER_MINUTE", "20") %>
+  anon_submission_rate_limit_per_minute: <%= ENV.fetch("JUDGE0_ANON_SUBMISSION_RATE_LIMIT_PER_MINUTE", "120") %>
   read_rate_limit_per_minute: <%= ENV.fetch("JUDGE0_READ_RATE_LIMIT_PER_MINUTE", "300") %>
   auth_positive_cache_ttl_seconds: <%= ENV.fetch("JUDGE0_AUTH_POSITIVE_CACHE_TTL_SECONDS", "300") %>
   auth_negative_cache_ttl_seconds: <%= ENV.fetch("JUDGE0_AUTH_NEGATIVE_CACHE_TTL_SECONDS", "60") %>
-  auth_cache_max_entries: <%= ENV.fetch("JUDGE0_AUTH_CACHE_MAX_ENTRIES", "2000") %>
+  auth_cache_max_entries: <%= ENV.fetch("JUDGE0_AUTH_CACHE_MAX_ENTRIES", "2500") %>
 
 development:
   <<: *default

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -3,6 +3,11 @@ default: &default
   authn_token: <%= ENV["AUTHN_TOKEN"].to_s.strip %>
   authz_header: <%= ENV["AUTHZ_HEADER"] %>
   authz_token: <%= ENV["AUTHZ_TOKEN"].to_s.strip %>
+  submission_service_token: <%= ENV["JUDGE0_SUBMISSION_SERVICE_TOKEN"].to_s.strip %>
+  judge0_auth_validate_url: <%= ENV["JUDGE0_AUTH_VALIDATE_URL"] %>
+  submission_rate_limit_per_minute: <%= ENV.fetch("JUDGE0_SUBMISSION_RATE_LIMIT_PER_MINUTE", "60") %>
+  auth_cache_ttl_seconds: <%= ENV.fetch("JUDGE0_AUTH_CACHE_TTL_SECONDS", "60") %>
+  rate_limit_redis_url: <%= ENV["JUDGE0_RATE_LIMIT_REDIS_URL"] || ENV["REDIS_URL"] %>
 
 development:
   <<: *default

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -7,6 +7,7 @@ default: &default
   judge0_auth_validate_url: <%= ENV["JUDGE0_AUTH_VALIDATE_URL"] %>
   submission_rate_limit_per_minute: <%= ENV.fetch("JUDGE0_SUBMISSION_RATE_LIMIT_PER_MINUTE", "60") %>
   auth_cache_ttl_seconds: <%= ENV.fetch("JUDGE0_AUTH_CACHE_TTL_SECONDS", "60") %>
+  auth_cache_max_entries: <%= ENV.fetch("JUDGE0_AUTH_CACHE_MAX_ENTRIES", "2000") %>
   rate_limit_redis_url: <%= ENV["JUDGE0_RATE_LIMIT_REDIS_URL"] || ENV["REDIS_URL"] %>
 
 development:

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -8,7 +8,7 @@ default: &default
   submission_rate_limit_per_minute: <%= ENV.fetch("JUDGE0_SUBMISSION_RATE_LIMIT_PER_MINUTE", "60") %>
   anon_submission_rate_limit_per_minute: <%= ENV.fetch("JUDGE0_ANON_SUBMISSION_RATE_LIMIT_PER_MINUTE", "20") %>
   read_rate_limit_per_minute: <%= ENV.fetch("JUDGE0_READ_RATE_LIMIT_PER_MINUTE", "300") %>
-  auth_cache_ttl_seconds: <%= ENV.fetch("JUDGE0_AUTH_CACHE_TTL_SECONDS", "60") %>
+  auth_positive_cache_ttl_seconds: <%= ENV.fetch("JUDGE0_AUTH_POSITIVE_CACHE_TTL_SECONDS", "300") %>
   auth_negative_cache_ttl_seconds: <%= ENV.fetch("JUDGE0_AUTH_NEGATIVE_CACHE_TTL_SECONDS", "60") %>
   auth_cache_max_entries: <%= ENV.fetch("JUDGE0_AUTH_CACHE_MAX_ENTRIES", "2000") %>
 

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -4,7 +4,7 @@ default: &default
   authz_header: <%= ENV["AUTHZ_HEADER"] %>
   authz_token: <%= ENV["AUTHZ_TOKEN"].to_s.strip %>
   submission_service_token: <%= ENV["JUDGE0_SUBMISSION_SERVICE_TOKEN"].to_s.strip %>
-  judge0_auth_validate_url: <%= ENV["JUDGE0_AUTH_VALIDATE_URL"] %>
+  judge0_auth_validate_url: <%= ENV.fetch("JUDGE0_AUTH_VALIDATE_URL", "http://newton-api.newton-services.svc.cluster.local:80/api/v1/user/auth/validate/") %>
   submission_rate_limit_per_minute: <%= ENV.fetch("JUDGE0_SUBMISSION_RATE_LIMIT_PER_MINUTE", "60") %>
   anon_submission_rate_limit_per_minute: <%= ENV.fetch("JUDGE0_ANON_SUBMISSION_RATE_LIMIT_PER_MINUTE", "120") %>
   read_rate_limit_per_minute: <%= ENV.fetch("JUDGE0_READ_RATE_LIMIT_PER_MINUTE", "300") %>

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -6,6 +6,8 @@ default: &default
   submission_service_token: <%= ENV["JUDGE0_SUBMISSION_SERVICE_TOKEN"].to_s.strip %>
   judge0_auth_validate_url: <%= ENV["JUDGE0_AUTH_VALIDATE_URL"] %>
   submission_rate_limit_per_minute: <%= ENV.fetch("JUDGE0_SUBMISSION_RATE_LIMIT_PER_MINUTE", "60") %>
+  anon_submission_rate_limit_per_minute: <%= ENV.fetch("JUDGE0_ANON_SUBMISSION_RATE_LIMIT_PER_MINUTE", "20") %>
+  read_rate_limit_per_minute: <%= ENV.fetch("JUDGE0_READ_RATE_LIMIT_PER_MINUTE", "300") %>
   auth_cache_ttl_seconds: <%= ENV.fetch("JUDGE0_AUTH_CACHE_TTL_SECONDS", "60") %>
   auth_cache_max_entries: <%= ENV.fetch("JUDGE0_AUTH_CACHE_MAX_ENTRIES", "2000") %>
   rate_limit_redis_url: <%= ENV["JUDGE0_RATE_LIMIT_REDIS_URL"] || ENV["REDIS_URL"] %>

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -9,8 +9,8 @@ default: &default
   anon_submission_rate_limit_per_minute: <%= ENV.fetch("JUDGE0_ANON_SUBMISSION_RATE_LIMIT_PER_MINUTE", "20") %>
   read_rate_limit_per_minute: <%= ENV.fetch("JUDGE0_READ_RATE_LIMIT_PER_MINUTE", "300") %>
   auth_cache_ttl_seconds: <%= ENV.fetch("JUDGE0_AUTH_CACHE_TTL_SECONDS", "60") %>
+  auth_negative_cache_ttl_seconds: <%= ENV.fetch("JUDGE0_AUTH_NEGATIVE_CACHE_TTL_SECONDS", "60") %>
   auth_cache_max_entries: <%= ENV.fetch("JUDGE0_AUTH_CACHE_MAX_ENTRIES", "2000") %>
-  rate_limit_redis_url: <%= ENV["JUDGE0_RATE_LIMIT_REDIS_URL"] || ENV["REDIS_URL"] %>
 
 development:
   <<: *default


### PR DESCRIPTION
> **Code only.** Specs are in stacked PR #40 (based on this branch). **Merge this first, then #40.**

## What
Closes the Judge Zero half of **NS-13252**. Judge0 accepts unauthenticated, unthrottled submissions in prod today (`AUTHN_TOKEN` unset → the native check is a no-op). This adds submission-scoped auth + per-user / per-IP rate limits, mirroring the Judge Pyro design (pyro #22). No IDOR work here — Judge0 submissions are already non-enumerable UUID tokens.

## How it works
A submissions-scoped concern `SubmissionAuthentication` on `create` / `batch_create` / `show` / `batch_show` reads `Authorization: Bearer <x>`:
- **No token → anonymous** (public playgrounds), allowed but rate-limited per client IP.
- **Service branch:** `x == JUDGE0_SUBMISSION_SERVICE_TOKEN` (constant-time) → trusted service (newton-api); bypasses all rate limits.
- **User branch:** validate `x` against the newton-api validate endpoint (`NewtonTokenValidator`), wrapped in the in-memory token cache (below) → per-user id. On a cache **miss**, the upstream validation is itself IP-throttled first (see below), so a flood of unique bad tokens can't amplify upstream calls / pin threads.
- Fails closed — invalid → 403, transient → 503; any limiter/Redis error → 503.

The global `AUTHN_TOKEN` switch is left untouched (stays a prod no-op) so `languages` / `statuses` / `info` remain open.

### Rate-limit tiers
| Caller | Create key | Read key | Default limit |
|---|---|---|---|
| service (newton-api) | bypass | bypass (grading fetches results via `show`) | — |
| logged-in user | `u:<user_id>` | `r:u:<user_id>` | 60/min create · 300/min read |
| anonymous | `ip:<client_ip>` | `r:<client_ip>` | 120/min create · 300/min read |

- **`batch_create` charges the batch size**, capped at `MAX_SUBMISSION_BATCH_SIZE`, so an N-submission batch consumes N units — not 1 (otherwise a 20-item batch was a 20× bypass of the create limit).
- **Cache-miss validations** are IP-throttled under `auth:<client_ip>` (at the anon-submission limit) before the upstream call — only on a cache miss, so cached/repeat tokens are unaffected.

### Client IP
The **last (rightmost) non-empty `X-Forwarded-For` entry** (the ALB appends the real client last; left-prepended entries are spoofs and are ignored), falling back to `request.remote_ip` when the header is absent. IPv6 is grouped by **/64** to match pyro. **IPv4-mapped IPv6 addresses (`::ffff:a.b.c.d`) are normalized to the real IPv4 first** — otherwise they all masked to `::` and collapsed into one shared bucket.

### Token cache (`CachingTokenValidator`)
Two hashes (positive / negative), **keyed by the SHA-256 digest of the token — never the raw bearer**. Ruby hashes are insertion-ordered, so the first entry is the earliest expiry and stores are **amortized O(1)** — no full-cache compaction. Only definitive answers are cached (user id or `:invalid`); transient errors never. At capacity a store **lazily reclaims at most one expired head entry**; if still full, the result isn't cached. Defaults: positive TTL **300s**, negative TTL **60s**, max **2500** entries (~1 MB).

### Redis
The rate limiter and token validator are **process-wide mutex-guarded singletons** — one Redis connection and one cache per process. The limiter's client is built from `REDIS_HOST` / `REDIS_PORT` / `REDIS_PASSWORD` — the same env `config/initializers/resque.rb` uses — so it shares the app's existing Redis; **no new connection URL to provision**. Keys are namespaced `judge0:rl:` and are always identities (`u:` / `ip:` / `r:` / `auth:`), never tokens. Fixed window per minute, global across pods, **fails closed (503)**.

## Config (`config/secrets.yml`)
`JUDGE0_SUBMISSION_SERVICE_TOKEN` (same value on newton-api), `JUDGE0_AUTH_VALIDATE_URL` (newton-api `GET /api/v1/user/auth/validate/` — **defaults to the in-cluster newton-api service, so it's optional**), and optional `JUDGE0_SUBMISSION_RATE_LIMIT_PER_MINUTE` (60), `JUDGE0_ANON_SUBMISSION_RATE_LIMIT_PER_MINUTE` (120), `JUDGE0_READ_RATE_LIMIT_PER_MINUTE` (300), `JUDGE0_AUTH_POSITIVE_CACHE_TTL_SECONDS` (300), `JUDGE0_AUTH_NEGATIVE_CACHE_TTL_SECONDS` (60), `JUDGE0_AUTH_CACHE_MAX_ENTRIES` (2500). Leave `AUTHN_TOKEN` unset.

## Request flow

```text
POST /submissions              (create / batch_create)
  |
  v  authenticate_submission_request
  |  read  Authorization: Bearer <token>
  |     |- no token .............. ANON     key ip:<client_ip>   (120/min)
  |     |- == service secret ..... SERVICE  (bypasses rate limit)
  |     `- else -> (cache miss? throttle auth:<client_ip>) validate @ newton-api  GET /api/v1/user/auth/validate/
  |                |- 401/403 .....> 403 "Invalid token"
  |                |- transient ...> 503  (fail closed)
  |                `- 200 ......... USER    key u:<user_id>      (60/min)
  |
  v  enforce_submission_rate_limit  (Redis fixed-window/min; charges batch size; global; fails closed (503))
        |- SERVICE ......... bypass
        |- over limit .....> 429 "Rate limit exceeded"
        `- under limit -> create submission


GET /submissions/{token}       (show / batch_show)
  |
  v  enforce_read_rate_limit    (300/min; fails closed (503))
        |- SERVICE ......... bypass       (grading fetches results via show)
        |- USER ............ key r:u:<user_id>
        |- ANON ............ key r:<client_ip>
        |- over limit .....> 429
        `- under limit ---> 200 | 404 if token unknown
```

## Review changes incorporated
- **IPv4-mapped IPv6 fix** — `::ffff:a.b.c.d` normalized to real IPv4 before /64 grouping (previously all collapsed to `ip:::/64`, one shared bucket).
- **`batch_create` charges the batch size** (capped at `MAX_SUBMISSION_BATCH_SIZE`) instead of one unit — closes a 20× bypass of the submission limit.
- **Cache-miss validations IP-throttled** before the upstream call — a unique-bad-token flood can't amplify load on newton-api or pin threads; cached tokens are unaffected.
- **Token cache keyed by SHA-256 digest** of the bearer — the raw token is never held in memory.
- **Validate URL defaults** to the in-cluster newton-api service.
- Client IP taken from the **last XFF entry**; signed-in **reads keyed per user** (`r:u:<user_id>`); cache compaction **lazy**; limiter reuses the app's `REDIS_HOST`/`REDIS_PORT`/`REDIS_PASSWORD` (dead `JUDGE0_RATE_LIMIT_REDIS_URL` removed); validator + limiter are process-wide singletons; anonymous limit raised **20 → 120/min**.

## Caveat
Fork has no CI. Files are `ruby -c` clean and the validator/limiter logic was verified against the live newton-api + real Redis, but the RSpec suite (in #40) has not been executed here — run `rspec` in the Docker dev stack before deploy.

Feature branch off master; not merged.
