### PR TITLE
[NS-13252] Judge0: submission auth + rate-limit specs (stacked on #39)

### DIFF
--- a/app/controllers/concerns/submission_authentication.rb
+++ b/app/controllers/concerns/submission_authentication.rb
@@ -14,7 +14,8 @@ module SubmissionAuthentication
         @token_validator ||= CachingTokenValidator.new(
           NewtonTokenValidator.new(Rails.application.secrets.judge0_auth_validate_url),
           ttl_seconds: Rails.application.secrets.auth_cache_ttl_seconds.to_i,
-          negative_ttl_seconds: 5
+          negative_ttl_seconds: 5,
+          max_entries: Rails.application.secrets.auth_cache_max_entries.to_i
         )
       end
     end
@@ -40,17 +41,17 @@ module SubmissionAuthentication
       return
     end
 
-    result =
+    validation_result =
       begin
         SubmissionAuthentication.token_validator.validate(token)
       rescue NewtonTokenValidator::TransientError
         return render_auth_error(503, "Auth temporarily unavailable")
       end
 
-    return render_auth_error(403, "Invalid token") if result == :invalid
+    return render_auth_error(403, "Invalid token") if validation_result == :invalid
 
     @is_service_caller = false
-    @current_user_id = result
+    @current_user_id = validation_result
   end
 
   def enforce_submission_rate_limit
@@ -67,15 +68,15 @@ module SubmissionAuthentication
   end
 
   def bearer_token
-    header = request.headers["Authorization"].to_s.strip
-    return nil unless header.downcase.start_with?("bearer ")
-    header[7..-1].to_s.strip
+    auth_header = request.headers["Authorization"].to_s.strip
+    return nil unless auth_header.downcase.start_with?("bearer ")
+    auth_header[7..-1].to_s.strip
   end
 
   def service_token?(token)
-    secret = Rails.application.secrets.submission_service_token.to_s
-    return false if secret.empty?
-    ActiveSupport::SecurityUtils.secure_compare(token, secret)
+    service_secret = Rails.application.secrets.submission_service_token.to_s
+    return false if service_secret.empty?
+    ActiveSupport::SecurityUtils.secure_compare(token, service_secret)
   end
 
   def render_auth_error(status, message)

--- a/app/controllers/concerns/submission_authentication.rb
+++ b/app/controllers/concerns/submission_authentication.rb
@@ -39,7 +39,7 @@ module SubmissionAuthentication
     if token.nil? || token.empty?
       @is_service_caller = false
       @is_anonymous = true
-      @client_ip = normalized_ip(request.remote_ip)
+      @client_ip = normalized_ip(client_ip)
       return
     end
 
@@ -87,7 +87,12 @@ module SubmissionAuthentication
     return if @is_service_caller
 
     begin
-      key = "r:#{normalized_ip(request.remote_ip)}"
+      if @is_anonymous
+        key = "r:#{@client_ip}"
+      else
+        return if @current_user_id.nil?
+        key = "r:u:#{@current_user_id}"
+      end
       limit = Rails.application.secrets.read_rate_limit_per_minute.to_i
       unless SubmissionAuthentication.rate_limiter.allow?(key, limit)
         render json: { error: "Rate limit exceeded" }, status: 429
@@ -102,6 +107,11 @@ module SubmissionAuthentication
     auth_header = request.headers["Authorization"].to_s.strip
     return nil unless auth_header.downcase.start_with?("bearer ")
     auth_header[7..-1].to_s.strip
+  end
+
+  def client_ip
+    forwarded = request.headers["X-Forwarded-For"].to_s.split(",").map(&:strip).reject(&:empty?)
+    forwarded.last || request.remote_ip
   end
 
   # Group IPv6 by /64 (matches pyro's client_ip normalization); IPv4 stays exact.

--- a/app/controllers/concerns/submission_authentication.rb
+++ b/app/controllers/concerns/submission_authentication.rb
@@ -2,7 +2,7 @@ require 'active_support/security_utils'
 require 'ipaddr'
 
 # Submission auth + rate limit (NS-13252): service secret bypasses; valid token -> per-user id,
-# no token -> anonymous per-IP; reads are IP-limited. Auth fails closed on invalid token; limiting fails open.
+# no token -> anonymous per-IP; reads are IP-limited. Auth and the limiter both fail closed (limiter error -> 503).
 module SubmissionAuthentication
   extend ActiveSupport::Concern
 
@@ -76,7 +76,8 @@ module SubmissionAuthentication
         render json: { error: "Rate limit exceeded" }, status: 429
       end
     rescue StandardError
-      # Fail open: a Redis blip (or limiter build failure) must not block submissions.
+      # Fail closed: a limiter/Redis failure returns a generic 503, not free passage.
+      render json: { error: "Service temporarily unavailable" }, status: 503
     end
   end
 
@@ -90,7 +91,8 @@ module SubmissionAuthentication
         render json: { error: "Rate limit exceeded" }, status: 429
       end
     rescue StandardError
-      # Fail open.
+      # Fail closed: a limiter/Redis failure returns a generic 503, not free passage.
+      render json: { error: "Service temporarily unavailable" }, status: 503
     end
   end
 

--- a/app/controllers/concerns/submission_authentication.rb
+++ b/app/controllers/concerns/submission_authentication.rb
@@ -14,7 +14,7 @@ module SubmissionAuthentication
       @token_validator || SINGLETON_MUTEX.synchronize do
         @token_validator ||= CachingTokenValidator.new(
           NewtonTokenValidator.new(Rails.application.secrets.judge0_auth_validate_url),
-          ttl_seconds: Rails.application.secrets.auth_cache_ttl_seconds.to_i,
+          ttl_seconds: Rails.application.secrets.auth_positive_cache_ttl_seconds.to_i,
           negative_ttl_seconds: Rails.application.secrets.auth_negative_cache_ttl_seconds.to_i,
           max_entries: Rails.application.secrets.auth_cache_max_entries.to_i
         )

--- a/app/controllers/concerns/submission_authentication.rb
+++ b/app/controllers/concerns/submission_authentication.rb
@@ -1,0 +1,84 @@
+require 'active_support/security_utils'
+
+# Submission auth + per-user rate limit (NS-13252): service secret bypasses the
+# limit, other tokens validate against newton-api. Auth fails closed; limiting fails open.
+module SubmissionAuthentication
+  extend ActiveSupport::Concern
+
+  # Process-wide singletons so the cache/Redis persist across requests (controller is per-request).
+  SINGLETON_MUTEX = Mutex.new
+
+  class << self
+    def token_validator
+      @token_validator || SINGLETON_MUTEX.synchronize do
+        @token_validator ||= CachingTokenValidator.new(
+          NewtonTokenValidator.new(Rails.application.secrets.judge0_auth_validate_url),
+          ttl_seconds: Rails.application.secrets.auth_cache_ttl_seconds.to_i,
+          negative_ttl_seconds: 5
+        )
+      end
+    end
+
+    def rate_limiter
+      @rate_limiter || SINGLETON_MUTEX.synchronize do
+        @rate_limiter ||= SubmissionRateLimiter.new(
+          Rails.application.secrets.rate_limit_redis_url,
+          Rails.application.secrets.submission_rate_limit_per_minute
+        )
+      end
+    end
+  end
+
+  private
+
+  def authenticate_submission_request
+    token = bearer_token
+    return render_auth_error(401, "Unauthorized") if token.nil? || token.empty?
+
+    if service_token?(token)
+      @is_service_caller = true
+      return
+    end
+
+    result =
+      begin
+        SubmissionAuthentication.token_validator.validate(token)
+      rescue NewtonTokenValidator::TransientError
+        return render_auth_error(503, "Auth temporarily unavailable")
+      end
+
+    return render_auth_error(403, "Invalid token") if result == :invalid
+
+    @is_service_caller = false
+    @current_user_id = result
+  end
+
+  def enforce_submission_rate_limit
+    return if @is_service_caller
+    return if @current_user_id.nil?
+
+    begin
+      unless SubmissionAuthentication.rate_limiter.allow?(@current_user_id)
+        render json: { error: "Rate limit exceeded" }, status: 429
+      end
+    rescue StandardError
+      # Fail open: a Redis blip (or limiter build failure) must not block submissions.
+    end
+  end
+
+  def bearer_token
+    header = request.headers["Authorization"].to_s.strip
+    return nil unless header.downcase.start_with?("bearer ")
+    header[7..-1].to_s.strip
+  end
+
+  def service_token?(token)
+    secret = Rails.application.secrets.submission_service_token.to_s
+    return false if secret.empty?
+    ActiveSupport::SecurityUtils.secure_compare(token, secret)
+  end
+
+  def render_auth_error(status, message)
+    render json: { error: message }, status: status
+  end
+end

--- a/app/controllers/concerns/submission_authentication.rb
+++ b/app/controllers/concerns/submission_authentication.rb
@@ -15,7 +15,7 @@ module SubmissionAuthentication
         @token_validator ||= CachingTokenValidator.new(
           NewtonTokenValidator.new(Rails.application.secrets.judge0_auth_validate_url),
           ttl_seconds: Rails.application.secrets.auth_cache_ttl_seconds.to_i,
-          negative_ttl_seconds: 5,
+          negative_ttl_seconds: Rails.application.secrets.auth_negative_cache_ttl_seconds.to_i,
           max_entries: Rails.application.secrets.auth_cache_max_entries.to_i
         )
       end
@@ -24,7 +24,9 @@ module SubmissionAuthentication
     def rate_limiter
       @rate_limiter || SINGLETON_MUTEX.synchronize do
         @rate_limiter ||= SubmissionRateLimiter.new(
-          Rails.application.secrets.rate_limit_redis_url
+          host: ENV["REDIS_HOST"],
+          port: ENV["REDIS_PORT"],
+          password: ENV["REDIS_PASSWORD"]
         )
       end
     end

--- a/app/controllers/concerns/submission_authentication.rb
+++ b/app/controllers/concerns/submission_authentication.rb
@@ -1,7 +1,8 @@
 require 'active_support/security_utils'
+require 'ipaddr'
 
-# Submission auth + per-user rate limit (NS-13252): service secret bypasses the
-# limit, other tokens validate against newton-api. Auth fails closed; limiting fails open.
+# Submission auth + rate limit (NS-13252): service secret bypasses; valid token -> per-user id,
+# no token -> anonymous per-IP; reads are IP-limited. Auth fails closed on invalid token; limiting fails open.
 module SubmissionAuthentication
   extend ActiveSupport::Concern
 
@@ -36,7 +37,7 @@ module SubmissionAuthentication
     if token.nil? || token.empty?
       @is_service_caller = false
       @is_anonymous = true
-      @client_ip = request.remote_ip
+      @client_ip = normalized_ip(request.remote_ip)
       return
     end
 
@@ -83,7 +84,7 @@ module SubmissionAuthentication
     return if @is_service_caller
 
     begin
-      key = "r:#{request.remote_ip}"
+      key = "r:#{normalized_ip(request.remote_ip)}"
       limit = Rails.application.secrets.read_rate_limit_per_minute.to_i
       unless SubmissionAuthentication.rate_limiter.allow?(key, limit)
         render json: { error: "Rate limit exceeded" }, status: 429
@@ -97,6 +98,14 @@ module SubmissionAuthentication
     auth_header = request.headers["Authorization"].to_s.strip
     return nil unless auth_header.downcase.start_with?("bearer ")
     auth_header[7..-1].to_s.strip
+  end
+
+  # Group IPv6 by /64 (matches pyro's client_ip normalization); IPv4 stays exact.
+  def normalized_ip(ip)
+    addr = IPAddr.new(ip.to_s)
+    addr.ipv6? ? "#{addr.mask(64)}/64" : ip.to_s
+  rescue IPAddr::InvalidAddressError
+    ip.to_s
   end
 
   def service_token?(token)

--- a/app/controllers/concerns/submission_authentication.rb
+++ b/app/controllers/concerns/submission_authentication.rb
@@ -36,16 +36,26 @@ module SubmissionAuthentication
 
   def authenticate_submission_request
     token = bearer_token
+    @client_ip = normalized_ip(client_ip)
+
     if token.nil? || token.empty?
       @is_service_caller = false
       @is_anonymous = true
-      @client_ip = normalized_ip(client_ip)
       return
     end
 
     if service_token?(token)
       @is_service_caller = true
       return
+    end
+
+    unless SubmissionAuthentication.token_validator.cached?(token)
+      begin
+        limit = Rails.application.secrets.anon_submission_rate_limit_per_minute.to_i
+        return render_auth_error(503, "Auth temporarily unavailable") unless SubmissionAuthentication.rate_limiter.allow?("auth:#{@client_ip}", limit)
+      rescue StandardError
+        return render_auth_error(503, "Auth temporarily unavailable")
+      end
     end
 
     validation_result =
@@ -74,7 +84,7 @@ module SubmissionAuthentication
         key = "u:#{@current_user_id}"
         limit = Rails.application.secrets.submission_rate_limit_per_minute.to_i
       end
-      unless SubmissionAuthentication.rate_limiter.allow?(key, limit)
+      unless SubmissionAuthentication.rate_limiter.allow?(key, limit, submission_cost)
         render json: { error: "Rate limit exceeded" }, status: 429
       end
     rescue StandardError
@@ -109,6 +119,11 @@ module SubmissionAuthentication
     auth_header[7..-1].to_s.strip
   end
 
+  def submission_cost
+    size = params[:submissions].respond_to?(:size) ? params[:submissions].size : 1
+    [[size, 1].max, Config::MAX_SUBMISSION_BATCH_SIZE].min
+  end
+
   def client_ip
     forwarded = request.headers["X-Forwarded-For"].to_s.split(",").map(&:strip).reject(&:empty?)
     forwarded.last || request.remote_ip
@@ -117,7 +132,8 @@ module SubmissionAuthentication
   # Group IPv6 by /64 (matches pyro's client_ip normalization); IPv4 stays exact.
   def normalized_ip(ip)
     addr = IPAddr.new(ip.to_s)
-    addr.ipv6? ? "#{addr.mask(64)}/64" : ip.to_s
+    addr = addr.native if addr.ipv4_mapped?
+    addr.ipv6? ? "#{addr.mask(64)}/64" : addr.to_s
   rescue IPAddr::InvalidAddressError
     ip.to_s
   end

--- a/app/controllers/concerns/submission_authentication.rb
+++ b/app/controllers/concerns/submission_authentication.rb
@@ -23,8 +23,7 @@ module SubmissionAuthentication
     def rate_limiter
       @rate_limiter || SINGLETON_MUTEX.synchronize do
         @rate_limiter ||= SubmissionRateLimiter.new(
-          Rails.application.secrets.rate_limit_redis_url,
-          Rails.application.secrets.submission_rate_limit_per_minute
+          Rails.application.secrets.rate_limit_redis_url
         )
       end
     end
@@ -34,7 +33,12 @@ module SubmissionAuthentication
 
   def authenticate_submission_request
     token = bearer_token
-    return render_auth_error(401, "Unauthorized") if token.nil? || token.empty?
+    if token.nil? || token.empty?
+      @is_service_caller = false
+      @is_anonymous = true
+      @client_ip = request.remote_ip
+      return
+    end
 
     if service_token?(token)
       @is_service_caller = true
@@ -51,19 +55,41 @@ module SubmissionAuthentication
     return render_auth_error(403, "Invalid token") if validation_result == :invalid
 
     @is_service_caller = false
+    @is_anonymous = false
     @current_user_id = validation_result
   end
 
   def enforce_submission_rate_limit
     return if @is_service_caller
-    return if @current_user_id.nil?
 
     begin
-      unless SubmissionAuthentication.rate_limiter.allow?(@current_user_id)
+      if @is_anonymous
+        key = "ip:#{@client_ip}"
+        limit = Rails.application.secrets.anon_submission_rate_limit_per_minute.to_i
+      else
+        return if @current_user_id.nil?
+        key = "u:#{@current_user_id}"
+        limit = Rails.application.secrets.submission_rate_limit_per_minute.to_i
+      end
+      unless SubmissionAuthentication.rate_limiter.allow?(key, limit)
         render json: { error: "Rate limit exceeded" }, status: 429
       end
     rescue StandardError
       # Fail open: a Redis blip (or limiter build failure) must not block submissions.
+    end
+  end
+
+  def enforce_read_rate_limit
+    return if @is_service_caller
+
+    begin
+      key = "r:#{request.remote_ip}"
+      limit = Rails.application.secrets.read_rate_limit_per_minute.to_i
+      unless SubmissionAuthentication.rate_limiter.allow?(key, limit)
+        render json: { error: "Rate limit exceeded" }, status: 429
+      end
+    rescue StandardError
+      # Fail open.
     end
   end
 

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -5,6 +5,7 @@ class SubmissionsController < ApplicationController
   # unauthenticated or throttled request is rejected before any queue work.
   before_action :authenticate_submission_request, only: [:create, :batch_create, :show, :batch_show]
   before_action :enforce_submission_rate_limit, only: [:create, :batch_create]
+  before_action :enforce_read_rate_limit, only: [:show, :batch_show]
 
   before_action :authorize_request, only: [:index, :destroy]
   before_action :check_maintenance, only: [:create, :destroy]

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -1,4 +1,11 @@
 class SubmissionsController < ApplicationController
+  include SubmissionAuthentication
+
+  # Auth + per-user rate limit run first, before the check_* filters, so an
+  # unauthenticated or throttled request is rejected before any queue work.
+  before_action :authenticate_submission_request, only: [:create, :batch_create, :show, :batch_show]
+  before_action :enforce_submission_rate_limit, only: [:create, :batch_create]
+
   before_action :authorize_request, only: [:index, :destroy]
   before_action :check_maintenance, only: [:create, :destroy]
   before_action :check_wait, only: [:create] # Wait in batch_create is not allowed

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -1,8 +1,7 @@
 class SubmissionsController < ApplicationController
   include SubmissionAuthentication
 
-  # Auth + per-user rate limit run first, before the check_* filters, so an
-  # unauthenticated or throttled request is rejected before any queue work.
+  # Authenticate, then rate-limit: per-user or per-IP on create/batch_create, per-IP on show/batch_show.
   before_action :authenticate_submission_request, only: [:create, :batch_create, :show, :batch_show]
   before_action :enforce_submission_rate_limit, only: [:create, :batch_create]
   before_action :enforce_read_rate_limit, only: [:show, :batch_show]

--- a/app/services/caching_token_validator.rb
+++ b/app/services/caching_token_validator.rb
@@ -1,12 +1,11 @@
 # In-memory TTL cache: positive/negative results cached (never transient), bounded, thread-safe.
 class CachingTokenValidator
-  MAX_ENTRIES = 50_000
-
-  def initialize(inner, ttl_seconds:, negative_ttl_seconds:,
+  def initialize(inner_validator, ttl_seconds:, negative_ttl_seconds:, max_entries:,
                  clock: -> { Process.clock_gettime(Process::CLOCK_MONOTONIC) })
-    @inner = inner
+    @inner_validator = inner_validator
     @ttl = ttl_seconds.to_i
     @negative_ttl = negative_ttl_seconds.to_i
+    @max_entries = max_entries.to_i
     @clock = clock
     @entries = {}
     @mutex = Mutex.new
@@ -20,12 +19,12 @@ class CachingTokenValidator
       return entry[:value] if entry && now < entry[:expires_at]
     end
 
-    value = @inner.validate(token) # may raise TransientError — intentionally not cached
+    value = @inner_validator.validate(token) # may raise TransientError — intentionally not cached
 
     ttl = value == :invalid ? @negative_ttl : @ttl
     @mutex.synchronize do
-      purge_expired(now) if @entries.size >= MAX_ENTRIES
-      @entries[token] = { value: value, expires_at: now + ttl } if @entries.size < MAX_ENTRIES
+      purge_expired(now) if @entries.size >= @max_entries
+      @entries[token] = { value: value, expires_at: now + ttl } if @entries.size < @max_entries
     end
     value
   end

--- a/app/services/caching_token_validator.rb
+++ b/app/services/caching_token_validator.rb
@@ -1,0 +1,38 @@
+# In-memory TTL cache: positive/negative results cached (never transient), bounded, thread-safe.
+class CachingTokenValidator
+  MAX_ENTRIES = 50_000
+
+  def initialize(inner, ttl_seconds:, negative_ttl_seconds:,
+                 clock: -> { Process.clock_gettime(Process::CLOCK_MONOTONIC) })
+    @inner = inner
+    @ttl = ttl_seconds.to_i
+    @negative_ttl = negative_ttl_seconds.to_i
+    @clock = clock
+    @entries = {}
+    @mutex = Mutex.new
+  end
+
+  # Returns a user id String or :invalid; raises on transient (not cached).
+  def validate(token)
+    now = @clock.call
+    @mutex.synchronize do
+      entry = @entries[token]
+      return entry[:value] if entry && now < entry[:expires_at]
+    end
+
+    value = @inner.validate(token) # may raise TransientError — intentionally not cached
+
+    ttl = value == :invalid ? @negative_ttl : @ttl
+    @mutex.synchronize do
+      purge_expired(now) if @entries.size >= MAX_ENTRIES
+      @entries[token] = { value: value, expires_at: now + ttl } if @entries.size < MAX_ENTRIES
+    end
+    value
+  end
+
+  private
+
+  def purge_expired(now)
+    @entries.delete_if { |_token, entry| now >= entry[:expires_at] }
+  end
+end

--- a/app/services/caching_token_validator.rb
+++ b/app/services/caching_token_validator.rb
@@ -7,7 +7,8 @@ class CachingTokenValidator
     @negative_ttl = negative_ttl_seconds.to_i
     @max_entries = max_entries.to_i
     @clock = clock
-    @entries = {}
+    @positive = {}
+    @negative = {}
     @mutex = Mutex.new
   end
 
@@ -15,23 +16,42 @@ class CachingTokenValidator
   def validate(token)
     now = @clock.call
     @mutex.synchronize do
-      entry = @entries[token]
+      entry = @positive[token] || @negative[token]
       return entry[:value] if entry && now < entry[:expires_at]
     end
 
     value = @inner_validator.validate(token) # may raise TransientError — intentionally not cached
 
-    ttl = value == :invalid ? @negative_ttl : @ttl
-    @mutex.synchronize do
-      purge_expired(now) if @entries.size >= @max_entries
-      @entries[token] = { value: value, expires_at: now + ttl } if @entries.size < @max_entries
-    end
+    store(now, token, value)
     value
   end
 
   private
 
+  def store(now, token, value)
+    if value == :invalid
+      cache, ttl = @negative, @negative_ttl
+    else
+      cache, ttl = @positive, @ttl
+    end
+
+    @mutex.synchronize do
+      @positive.delete(token)
+      @negative.delete(token)
+      purge_expired(now)
+      return if @positive.size + @negative.size >= @max_entries
+
+      cache[token] = { value: value, expires_at: now + ttl }
+    end
+  end
+
   def purge_expired(now)
-    @entries.delete_if { |_token, entry| now >= entry[:expires_at] }
+    [@positive, @negative].each do |cache|
+      while (pair = cache.first)
+        break if now < pair[1][:expires_at]
+
+        cache.shift
+      end
+    end
   end
 end

--- a/app/services/caching_token_validator.rb
+++ b/app/services/caching_token_validator.rb
@@ -26,6 +26,14 @@ class CachingTokenValidator
     value
   end
 
+  def cached?(token)
+    now = @clock.call
+    @mutex.synchronize do
+      entry = @positive[token] || @negative[token]
+      !entry.nil? && now < entry[:expires_at]
+    end
+  end
+
   private
 
   def store(now, token, value)

--- a/app/services/caching_token_validator.rb
+++ b/app/services/caching_token_validator.rb
@@ -1,3 +1,5 @@
+require "digest"
+
 # In-memory TTL cache: positive/negative results cached (never transient), bounded, thread-safe.
 class CachingTokenValidator
   def initialize(inner_validator, ttl_seconds:, negative_ttl_seconds:, max_entries:,
@@ -15,28 +17,34 @@ class CachingTokenValidator
   # Returns a user id String or :invalid; raises on transient (not cached).
   def validate(token)
     now = @clock.call
+    key = digest(token)
     @mutex.synchronize do
-      entry = @positive[token] || @negative[token]
+      entry = @positive[key] || @negative[key]
       return entry[:value] if entry && now < entry[:expires_at]
     end
 
     value = @inner_validator.validate(token) # may raise TransientError — intentionally not cached
 
-    store(now, token, value)
+    store(now, key, value)
     value
   end
 
   def cached?(token)
     now = @clock.call
+    key = digest(token)
     @mutex.synchronize do
-      entry = @positive[token] || @negative[token]
+      entry = @positive[key] || @negative[key]
       !entry.nil? && now < entry[:expires_at]
     end
   end
 
   private
 
-  def store(now, token, value)
+  def digest(token)
+    Digest::SHA256.hexdigest(token)
+  end
+
+  def store(now, key, value)
     if value == :invalid
       cache, ttl = @negative, @negative_ttl
     else
@@ -44,12 +52,12 @@ class CachingTokenValidator
     end
 
     @mutex.synchronize do
-      @positive.delete(token)
-      @negative.delete(token)
+      @positive.delete(key)
+      @negative.delete(key)
       evict_one_expired(now) if @positive.size + @negative.size >= @max_entries
       return if @positive.size + @negative.size >= @max_entries
 
-      cache[token] = { value: value, expires_at: now + ttl }
+      cache[key] = { value: value, expires_at: now + ttl }
     end
   end
 

--- a/app/services/caching_token_validator.rb
+++ b/app/services/caching_token_validator.rb
@@ -38,20 +38,20 @@ class CachingTokenValidator
     @mutex.synchronize do
       @positive.delete(token)
       @negative.delete(token)
-      purge_expired(now)
+      evict_one_expired(now) if @positive.size + @negative.size >= @max_entries
       return if @positive.size + @negative.size >= @max_entries
 
       cache[token] = { value: value, expires_at: now + ttl }
     end
   end
 
-  def purge_expired(now)
+  def evict_one_expired(now)
     [@positive, @negative].each do |cache|
-      while (pair = cache.first)
-        break if now < pair[1][:expires_at]
+      pair = cache.first
+      next unless pair && now >= pair[1][:expires_at]
 
-        cache.shift
-      end
+      cache.shift
+      return
     end
   end
 end

--- a/app/services/newton_token_validator.rb
+++ b/app/services/newton_token_validator.rb
@@ -1,0 +1,40 @@
+require 'net/http'
+require 'json'
+require 'uri'
+
+# Validates a Bearer token via the newton-api endpoint (Judge0 holds no secret of its own).
+class NewtonTokenValidator
+  class TransientError < StandardError; end
+
+  def initialize(validate_url)
+    @validate_url = validate_url
+  end
+
+  # Returns user id, :invalid (401/403), or raises TransientError (caller fails closed).
+  def validate(token)
+    uri = URI.parse(@validate_url)
+    req = Net::HTTP::Get.new(uri)
+    req["Authorization"] = "Bearer #{token}"
+
+    resp = Net::HTTP.start(
+      uri.host, uri.port,
+      use_ssl: uri.scheme == "https", open_timeout: 3, read_timeout: 3
+    ) { |http| http.request(req) }
+
+    case resp.code.to_i
+    when 200
+      user_id = JSON.parse(resp.body)["user_id"]
+      raise TransientError, "empty user_id" if user_id.nil? || user_id.to_s.empty?
+      user_id.to_s
+    when 401, 403
+      :invalid
+    else
+      raise TransientError, "unexpected status #{resp.code}"
+    end
+  rescue TransientError
+    raise
+  rescue StandardError => e
+    # Any network/TLS/parse failure is transient → fail closed (503), never a 500.
+    raise TransientError, e.message
+  end
+end

--- a/app/services/newton_token_validator.rb
+++ b/app/services/newton_token_validator.rb
@@ -13,28 +13,28 @@ class NewtonTokenValidator
   # Returns user id, :invalid (401/403), or raises TransientError (caller fails closed).
   def validate(token)
     uri = URI.parse(@validate_url)
-    req = Net::HTTP::Get.new(uri)
-    req["Authorization"] = "Bearer #{token}"
+    request = Net::HTTP::Get.new(uri)
+    request["Authorization"] = "Bearer #{token}"
 
-    resp = Net::HTTP.start(
+    response = Net::HTTP.start(
       uri.host, uri.port,
       use_ssl: uri.scheme == "https", open_timeout: 3, read_timeout: 3
-    ) { |http| http.request(req) }
+    ) { |http| http.request(request) }
 
-    case resp.code.to_i
+    case response.code.to_i
     when 200
-      user_id = JSON.parse(resp.body)["user_id"]
+      user_id = JSON.parse(response.body)["user_id"]
       raise TransientError, "empty user_id" if user_id.nil? || user_id.to_s.empty?
       user_id.to_s
     when 401, 403
       :invalid
     else
-      raise TransientError, "unexpected status #{resp.code}"
+      raise TransientError, "unexpected status #{response.code}"
     end
   rescue TransientError
     raise
-  rescue StandardError => e
+  rescue StandardError => error
     # Any network/TLS/parse failure is transient → fail closed (503), never a 500.
-    raise TransientError, e.message
+    raise TransientError, error.message
   end
 end

--- a/app/services/submission_rate_limiter.rb
+++ b/app/services/submission_rate_limiter.rb
@@ -8,11 +8,11 @@ class SubmissionRateLimiter
   end
 
   # true if the key is within the given one-minute budget; raises on Redis error.
-  def allow?(key, limit)
+  def allow?(key, limit, amount = 1)
     window = @clock.call / 60
     redis_key = "judge0:rl:#{key}:#{window}"
-    count = @redis.incr(redis_key)
-    @redis.expire(redis_key, 70) if count == 1
+    count = amount == 1 ? @redis.incr(redis_key) : @redis.incrby(redis_key, amount)
+    @redis.expire(redis_key, 70) if count == amount
     count <= limit.to_i
   end
 end

--- a/app/services/submission_rate_limiter.rb
+++ b/app/services/submission_rate_limiter.rb
@@ -1,19 +1,18 @@
 require 'redis'
 
-# Redis fixed-window per-user limiter, global across pods; raises on Redis error (caller fails open).
+# Redis fixed-window per-minute limiter, global across pods; raises on Redis error (caller fails open).
 class SubmissionRateLimiter
-  def initialize(redis_url, per_minute_limit, clock: -> { Time.now.to_i })
+  def initialize(redis_url, clock: -> { Time.now.to_i })
     @redis = Redis.new(url: redis_url)
-    @limit = per_minute_limit.to_i
     @clock = clock
   end
 
-  # true if the key is within its one-minute budget; raises on Redis error (caller fails open).
-  def allow?(key)
+  # true if the key is within the given one-minute budget; raises on Redis error (caller fails open).
+  def allow?(key, limit)
     window = @clock.call / 60
     redis_key = "judge0:rl:#{key}:#{window}"
     count = @redis.incr(redis_key)
     @redis.expire(redis_key, 70) if count == 1
-    count <= @limit
+    count <= limit.to_i
   end
 end

--- a/app/services/submission_rate_limiter.rb
+++ b/app/services/submission_rate_limiter.rb
@@ -1,0 +1,19 @@
+require 'redis'
+
+# Redis fixed-window per-user limiter, global across pods; raises on Redis error (caller fails open).
+class SubmissionRateLimiter
+  def initialize(redis_url, per_minute_limit, clock: -> { Time.now.to_i })
+    @redis = Redis.new(url: redis_url)
+    @limit = per_minute_limit.to_i
+    @clock = clock
+  end
+
+  # true if the key is within its one-minute budget; raises on Redis error (caller fails open).
+  def allow?(key)
+    window = @clock.call / 60
+    redis_key = "judge0:rl:#{key}:#{window}"
+    count = @redis.incr(redis_key)
+    @redis.expire(redis_key, 70) if count == 1
+    count <= @limit
+  end
+end

--- a/app/services/submission_rate_limiter.rb
+++ b/app/services/submission_rate_limiter.rb
@@ -1,13 +1,13 @@
 require 'redis'
 
-# Redis fixed-window per-minute limiter, global across pods; raises on Redis error (caller fails open).
+# Redis fixed-window per-minute limiter, global across pods; raises on Redis error.
 class SubmissionRateLimiter
-  def initialize(redis_url, clock: -> { Time.now.to_i })
-    @redis = Redis.new(url: redis_url)
+  def initialize(host:, port:, password:, clock: -> { Time.now.to_i })
+    @redis = Redis.new(host: host, port: port, password: password)
     @clock = clock
   end
 
-  # true if the key is within the given one-minute budget; raises on Redis error (caller fails open).
+  # true if the key is within the given one-minute budget; raises on Redis error.
   def allow?(key, limit)
     window = @clock.call / 60
     redis_key = "judge0:rl:#{key}:#{window}"

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -6,11 +6,11 @@ default: &default
   submission_service_token: <%= ENV["JUDGE0_SUBMISSION_SERVICE_TOKEN"].to_s.strip %>
   judge0_auth_validate_url: <%= ENV["JUDGE0_AUTH_VALIDATE_URL"] %>
   submission_rate_limit_per_minute: <%= ENV.fetch("JUDGE0_SUBMISSION_RATE_LIMIT_PER_MINUTE", "60") %>
-  anon_submission_rate_limit_per_minute: <%= ENV.fetch("JUDGE0_ANON_SUBMISSION_RATE_LIMIT_PER_MINUTE", "20") %>
+  anon_submission_rate_limit_per_minute: <%= ENV.fetch("JUDGE0_ANON_SUBMISSION_RATE_LIMIT_PER_MINUTE", "120") %>
   read_rate_limit_per_minute: <%= ENV.fetch("JUDGE0_READ_RATE_LIMIT_PER_MINUTE", "300") %>
   auth_positive_cache_ttl_seconds: <%= ENV.fetch("JUDGE0_AUTH_POSITIVE_CACHE_TTL_SECONDS", "300") %>
   auth_negative_cache_ttl_seconds: <%= ENV.fetch("JUDGE0_AUTH_NEGATIVE_CACHE_TTL_SECONDS", "60") %>
-  auth_cache_max_entries: <%= ENV.fetch("JUDGE0_AUTH_CACHE_MAX_ENTRIES", "2000") %>
+  auth_cache_max_entries: <%= ENV.fetch("JUDGE0_AUTH_CACHE_MAX_ENTRIES", "2500") %>
 
 development:
   <<: *default

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -3,6 +3,11 @@ default: &default
   authn_token: <%= ENV["AUTHN_TOKEN"].to_s.strip %>
   authz_header: <%= ENV["AUTHZ_HEADER"] %>
   authz_token: <%= ENV["AUTHZ_TOKEN"].to_s.strip %>
+  submission_service_token: <%= ENV["JUDGE0_SUBMISSION_SERVICE_TOKEN"].to_s.strip %>
+  judge0_auth_validate_url: <%= ENV["JUDGE0_AUTH_VALIDATE_URL"] %>
+  submission_rate_limit_per_minute: <%= ENV.fetch("JUDGE0_SUBMISSION_RATE_LIMIT_PER_MINUTE", "60") %>
+  auth_cache_ttl_seconds: <%= ENV.fetch("JUDGE0_AUTH_CACHE_TTL_SECONDS", "60") %>
+  rate_limit_redis_url: <%= ENV["JUDGE0_RATE_LIMIT_REDIS_URL"] || ENV["REDIS_URL"] %>
 
 development:
   <<: *default

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -7,6 +7,7 @@ default: &default
   judge0_auth_validate_url: <%= ENV["JUDGE0_AUTH_VALIDATE_URL"] %>
   submission_rate_limit_per_minute: <%= ENV.fetch("JUDGE0_SUBMISSION_RATE_LIMIT_PER_MINUTE", "60") %>
   auth_cache_ttl_seconds: <%= ENV.fetch("JUDGE0_AUTH_CACHE_TTL_SECONDS", "60") %>
+  auth_cache_max_entries: <%= ENV.fetch("JUDGE0_AUTH_CACHE_MAX_ENTRIES", "2000") %>
   rate_limit_redis_url: <%= ENV["JUDGE0_RATE_LIMIT_REDIS_URL"] || ENV["REDIS_URL"] %>
 
 development:

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -8,7 +8,7 @@ default: &default
   submission_rate_limit_per_minute: <%= ENV.fetch("JUDGE0_SUBMISSION_RATE_LIMIT_PER_MINUTE", "60") %>
   anon_submission_rate_limit_per_minute: <%= ENV.fetch("JUDGE0_ANON_SUBMISSION_RATE_LIMIT_PER_MINUTE", "20") %>
   read_rate_limit_per_minute: <%= ENV.fetch("JUDGE0_READ_RATE_LIMIT_PER_MINUTE", "300") %>
-  auth_cache_ttl_seconds: <%= ENV.fetch("JUDGE0_AUTH_CACHE_TTL_SECONDS", "60") %>
+  auth_positive_cache_ttl_seconds: <%= ENV.fetch("JUDGE0_AUTH_POSITIVE_CACHE_TTL_SECONDS", "300") %>
   auth_negative_cache_ttl_seconds: <%= ENV.fetch("JUDGE0_AUTH_NEGATIVE_CACHE_TTL_SECONDS", "60") %>
   auth_cache_max_entries: <%= ENV.fetch("JUDGE0_AUTH_CACHE_MAX_ENTRIES", "2000") %>
 

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -4,7 +4,7 @@ default: &default
   authz_header: <%= ENV["AUTHZ_HEADER"] %>
   authz_token: <%= ENV["AUTHZ_TOKEN"].to_s.strip %>
   submission_service_token: <%= ENV["JUDGE0_SUBMISSION_SERVICE_TOKEN"].to_s.strip %>
-  judge0_auth_validate_url: <%= ENV["JUDGE0_AUTH_VALIDATE_URL"] %>
+  judge0_auth_validate_url: <%= ENV.fetch("JUDGE0_AUTH_VALIDATE_URL", "http://newton-api.newton-services.svc.cluster.local:80/api/v1/user/auth/validate/") %>
   submission_rate_limit_per_minute: <%= ENV.fetch("JUDGE0_SUBMISSION_RATE_LIMIT_PER_MINUTE", "60") %>
   anon_submission_rate_limit_per_minute: <%= ENV.fetch("JUDGE0_ANON_SUBMISSION_RATE_LIMIT_PER_MINUTE", "120") %>
   read_rate_limit_per_minute: <%= ENV.fetch("JUDGE0_READ_RATE_LIMIT_PER_MINUTE", "300") %>

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -6,6 +6,8 @@ default: &default
   submission_service_token: <%= ENV["JUDGE0_SUBMISSION_SERVICE_TOKEN"].to_s.strip %>
   judge0_auth_validate_url: <%= ENV["JUDGE0_AUTH_VALIDATE_URL"] %>
   submission_rate_limit_per_minute: <%= ENV.fetch("JUDGE0_SUBMISSION_RATE_LIMIT_PER_MINUTE", "60") %>
+  anon_submission_rate_limit_per_minute: <%= ENV.fetch("JUDGE0_ANON_SUBMISSION_RATE_LIMIT_PER_MINUTE", "20") %>
+  read_rate_limit_per_minute: <%= ENV.fetch("JUDGE0_READ_RATE_LIMIT_PER_MINUTE", "300") %>
   auth_cache_ttl_seconds: <%= ENV.fetch("JUDGE0_AUTH_CACHE_TTL_SECONDS", "60") %>
   auth_cache_max_entries: <%= ENV.fetch("JUDGE0_AUTH_CACHE_MAX_ENTRIES", "2000") %>
   rate_limit_redis_url: <%= ENV["JUDGE0_RATE_LIMIT_REDIS_URL"] || ENV["REDIS_URL"] %>

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -9,8 +9,8 @@ default: &default
   anon_submission_rate_limit_per_minute: <%= ENV.fetch("JUDGE0_ANON_SUBMISSION_RATE_LIMIT_PER_MINUTE", "20") %>
   read_rate_limit_per_minute: <%= ENV.fetch("JUDGE0_READ_RATE_LIMIT_PER_MINUTE", "300") %>
   auth_cache_ttl_seconds: <%= ENV.fetch("JUDGE0_AUTH_CACHE_TTL_SECONDS", "60") %>
+  auth_negative_cache_ttl_seconds: <%= ENV.fetch("JUDGE0_AUTH_NEGATIVE_CACHE_TTL_SECONDS", "60") %>
   auth_cache_max_entries: <%= ENV.fetch("JUDGE0_AUTH_CACHE_MAX_ENTRIES", "2000") %>
-  rate_limit_redis_url: <%= ENV["JUDGE0_RATE_LIMIT_REDIS_URL"] || ENV["REDIS_URL"] %>
 
 development:
   <<: *default

--- a/spec/controllers/submissions_controller_spec.rb
+++ b/spec/controllers/submissions_controller_spec.rb
@@ -4,6 +4,13 @@ RSpec.describe SubmissionsController, type: :controller do
 
   let(:submission) { create(:submission) }
 
+  # Submission endpoints now require a bearer; authenticate every example as the
+  # trusted service caller so these pre-existing behaviour tests are unaffected.
+  before do
+    allow(Rails.application.secrets).to receive(:submission_service_token).and_return("svc-secret")
+    request.headers["Authorization"] = "Bearer svc-secret"
+  end
+
   describe "GET #show" do
     it "returns one submission" do
       get :show, params: { token: submission.token }

--- a/spec/requests/submission_authentication_spec.rb
+++ b/spec/requests/submission_authentication_spec.rb
@@ -20,9 +20,9 @@ RSpec.describe "Submission authentication", type: :request do
   end
 
   describe "auth branch" do
-    it "401 without a bearer" do
-      get "/submissions/anytoken"
-      expect(response.status).to eq(401)
+    it "does not 401 an anonymous request without a bearer" do
+      post "/submissions", params: attributes_for(:valid_submission)
+      expect(response.status).not_to eq(401)
     end
 
     it "403 with an invalid bearer" do
@@ -71,6 +71,45 @@ RSpec.describe "Submission authentication", type: :request do
       allow(@limiter).to receive(:allow?).and_raise(StandardError.new("redis down"))
       post "/submissions", params: attributes_for(:valid_submission),
                            headers: { "Authorization" => "Bearer user-tok" }
+      expect(response.status).not_to eq(429)
+    end
+
+    it "rate-limits an anonymous caller by IP" do
+      expect(@limiter).to receive(:allow?).with("ip:203.0.113.9", anything).and_return(true)
+      post "/submissions", params: attributes_for(:valid_submission),
+                           env: { "REMOTE_ADDR" => "203.0.113.9" }
+    end
+
+    it "rate-limits a logged-in caller by user id" do
+      expect(@limiter).to receive(:allow?).with("u:user-1", anything).and_return(true)
+      post "/submissions", params: attributes_for(:valid_submission),
+                           headers: { "Authorization" => "Bearer user-tok" }
+    end
+
+    it "does not call the rate limiter for the service caller" do
+      expect(@limiter).not_to receive(:allow?)
+      post "/submissions", params: attributes_for(:valid_submission),
+                           headers: { "Authorization" => "Bearer #{service_token}" }
+    end
+
+    it "429s an anonymous caller over the per-minute limit" do
+      allow(@limiter).to receive(:allow?).and_return(false)
+      post "/submissions", params: attributes_for(:valid_submission)
+      expect(response.status).to eq(429)
+    end
+  end
+
+  describe "read rate limit" do
+    it "429s a read over the per-minute limit" do
+      allow(@limiter).to receive(:allow?).and_return(false)
+      get "/submissions/anytoken"
+      expect(response.status).to eq(429)
+    end
+
+    it "does not call the rate limiter for the service caller's read" do
+      submission = create(:submission)
+      expect(@limiter).not_to receive(:allow?)
+      get "/submissions/#{submission.token}", headers: { "Authorization" => "Bearer #{service_token}" }
       expect(response.status).not_to eq(429)
     end
   end

--- a/spec/requests/submission_authentication_spec.rb
+++ b/spec/requests/submission_authentication_spec.rb
@@ -67,11 +67,11 @@ RSpec.describe "Submission authentication", type: :request do
       expect(response.status).not_to eq(429)
     end
 
-    it "fails open when the limiter raises (Redis down)" do
+    it "fails closed with 503 when the limiter raises (Redis down)" do
       allow(@limiter).to receive(:allow?).and_raise(StandardError.new("redis down"))
       post "/submissions", params: attributes_for(:valid_submission),
                            headers: { "Authorization" => "Bearer user-tok" }
-      expect(response.status).not_to eq(429)
+      expect(response.status).to eq(503)
     end
 
     it "rate-limits an anonymous caller by IP" do
@@ -110,6 +110,12 @@ RSpec.describe "Submission authentication", type: :request do
       expect(@limiter).to receive(:allow?).with("r:203.0.113.9", anything).and_return(false)
       get "/submissions/anytoken", env: { "REMOTE_ADDR" => "203.0.113.9" }
       expect(response.status).to eq(429)
+    end
+
+    it "fails closed with 503 when the read limiter raises" do
+      allow(@limiter).to receive(:allow?).and_raise(StandardError.new("redis down"))
+      get "/submissions/anytoken", env: { "REMOTE_ADDR" => "203.0.113.9" }
+      expect(response.status).to eq(503)
     end
 
     it "does not call the rate limiter for the service caller's read" do

--- a/spec/requests/submission_authentication_spec.rb
+++ b/spec/requests/submission_authentication_spec.rb
@@ -80,6 +80,12 @@ RSpec.describe "Submission authentication", type: :request do
                            env: { "REMOTE_ADDR" => "203.0.113.9" }
     end
 
+    it "takes the client IP from the last X-Forwarded-For entry" do
+      expect(@limiter).to receive(:allow?).with("ip:203.0.113.9", anything).and_return(true)
+      post "/submissions", params: attributes_for(:valid_submission),
+                           env: { "HTTP_X_FORWARDED_FOR" => "1.1.1.1, 203.0.113.9" }
+    end
+
     it "groups an anonymous IPv6 caller by /64" do
       expect(@limiter).to receive(:allow?).with("ip:2001:db8:abcd:1234::/64", anything).and_return(true)
       post "/submissions", params: attributes_for(:valid_submission),
@@ -110,6 +116,11 @@ RSpec.describe "Submission authentication", type: :request do
       expect(@limiter).to receive(:allow?).with("r:203.0.113.9", anything).and_return(false)
       get "/submissions/anytoken", env: { "REMOTE_ADDR" => "203.0.113.9" }
       expect(response.status).to eq(429)
+    end
+
+    it "keys a signed-in read by user id" do
+      expect(@limiter).to receive(:allow?).with("r:u:user-1", anything).and_return(true)
+      get "/submissions/anytoken", headers: { "Authorization" => "Bearer user-tok" }
     end
 
     it "fails closed with 503 when the read limiter raises" do

--- a/spec/requests/submission_authentication_spec.rb
+++ b/spec/requests/submission_authentication_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+RSpec.describe "Submission authentication", type: :request do
+  let(:service_token) { "svc-secret" }
+
+  before do
+    allow(Rails.application.secrets).to receive(:submission_service_token).and_return(service_token)
+
+    # Stub the process-wide singletons the concern uses, so no network / Redis
+    # is hit and the real singletons are never built (RSpec tears these down
+    # after each example → no cross-test leakage).
+    @validator = instance_double(CachingTokenValidator)
+    allow(@validator).to receive(:validate).with("user-tok").and_return("user-1")
+    allow(@validator).to receive(:validate).with("bad-tok").and_return(:invalid)
+    allow(SubmissionAuthentication).to receive(:token_validator).and_return(@validator)
+
+    @limiter = instance_double(SubmissionRateLimiter)
+    allow(@limiter).to receive(:allow?).and_return(true)
+    allow(SubmissionAuthentication).to receive(:rate_limiter).and_return(@limiter)
+  end
+
+  describe "auth branch" do
+    it "401 without a bearer" do
+      get "/submissions/anytoken"
+      expect(response.status).to eq(401)
+    end
+
+    it "403 with an invalid bearer" do
+      get "/submissions/anytoken", headers: { "Authorization" => "Bearer bad-tok" }
+      expect(response.status).to eq(403)
+    end
+
+    it "503 when the validator is transiently unavailable (fail closed)" do
+      allow(@validator).to receive(:validate)
+        .and_raise(NewtonTokenValidator::TransientError.new("down"))
+      get "/submissions/anytoken", headers: { "Authorization" => "Bearer whatever" }
+      expect(response.status).to eq(503)
+    end
+
+    it "allows the service token" do
+      post "/submissions", params: attributes_for(:valid_submission),
+                           headers: { "Authorization" => "Bearer #{service_token}" }
+      expect(response.status).not_to eq(401)
+      expect(response.status).not_to eq(403)
+    end
+
+    it "allows a valid user bearer" do
+      post "/submissions", params: attributes_for(:valid_submission),
+                           headers: { "Authorization" => "Bearer user-tok" }
+      expect(response.status).not_to eq(401)
+      expect(response.status).not_to eq(403)
+    end
+  end
+
+  describe "rate limit" do
+    it "429s a user over the per-minute limit" do
+      allow(@limiter).to receive(:allow?).and_return(false)
+      post "/submissions", params: attributes_for(:valid_submission),
+                           headers: { "Authorization" => "Bearer user-tok" }
+      expect(response.status).to eq(429)
+    end
+
+    it "does not rate-limit the service caller even when the limiter would block" do
+      allow(@limiter).to receive(:allow?).and_return(false)
+      post "/submissions", params: attributes_for(:valid_submission),
+                           headers: { "Authorization" => "Bearer #{service_token}" }
+      expect(response.status).not_to eq(429)
+    end
+
+    it "fails open when the limiter raises (Redis down)" do
+      allow(@limiter).to receive(:allow?).and_raise(StandardError.new("redis down"))
+      post "/submissions", params: attributes_for(:valid_submission),
+                           headers: { "Authorization" => "Bearer user-tok" }
+      expect(response.status).not_to eq(429)
+    end
+  end
+end

--- a/spec/requests/submission_authentication_spec.rb
+++ b/spec/requests/submission_authentication_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "Submission authentication", type: :request do
     @validator = instance_double(CachingTokenValidator)
     allow(@validator).to receive(:validate).with("user-tok").and_return("user-1")
     allow(@validator).to receive(:validate).with("bad-tok").and_return(:invalid)
+    allow(@validator).to receive(:cached?).and_return(true)
     allow(SubmissionAuthentication).to receive(:token_validator).and_return(@validator)
 
     @limiter = instance_double(SubmissionRateLimiter)
@@ -75,27 +76,45 @@ RSpec.describe "Submission authentication", type: :request do
     end
 
     it "rate-limits an anonymous caller by IP" do
-      expect(@limiter).to receive(:allow?).with("ip:203.0.113.9", anything).and_return(true)
+      expect(@limiter).to receive(:allow?).with("ip:203.0.113.9", anything, anything).and_return(true)
       post "/submissions", params: attributes_for(:valid_submission),
                            env: { "REMOTE_ADDR" => "203.0.113.9" }
     end
 
     it "takes the client IP from the last X-Forwarded-For entry" do
-      expect(@limiter).to receive(:allow?).with("ip:203.0.113.9", anything).and_return(true)
+      expect(@limiter).to receive(:allow?).with("ip:203.0.113.9", anything, anything).and_return(true)
       post "/submissions", params: attributes_for(:valid_submission),
                            env: { "HTTP_X_FORWARDED_FOR" => "1.1.1.1, 203.0.113.9" }
     end
 
     it "groups an anonymous IPv6 caller by /64" do
-      expect(@limiter).to receive(:allow?).with("ip:2001:db8:abcd:1234::/64", anything).and_return(true)
+      expect(@limiter).to receive(:allow?).with("ip:2001:db8:abcd:1234::/64", anything, anything).and_return(true)
       post "/submissions", params: attributes_for(:valid_submission),
                            env: { "REMOTE_ADDR" => "2001:db8:abcd:1234:ffff::1" }
     end
 
     it "rate-limits a logged-in caller by user id" do
-      expect(@limiter).to receive(:allow?).with("u:user-1", anything).and_return(true)
+      expect(@limiter).to receive(:allow?).with("u:user-1", anything, anything).and_return(true)
       post "/submissions", params: attributes_for(:valid_submission),
                            headers: { "Authorization" => "Bearer user-tok" }
+    end
+
+    it "charges the batch size against the rate limit" do
+      expect(@limiter).to receive(:allow?).with("ip:203.0.113.9", anything, 3).and_return(true)
+      post "/submissions/batch",
+           params: { submissions: [attributes_for(:valid_submission),
+                                   attributes_for(:valid_submission),
+                                   attributes_for(:valid_submission)] },
+           env: { "REMOTE_ADDR" => "203.0.113.9" }
+    end
+
+    it "throttles a cache-miss validation by IP and fails closed over the limit" do
+      allow(@validator).to receive(:cached?).and_return(false)
+      expect(@limiter).to receive(:allow?).with("auth:203.0.113.9", anything).and_return(false)
+      post "/submissions", params: attributes_for(:valid_submission),
+                           env: { "REMOTE_ADDR" => "203.0.113.9" },
+                           headers: { "Authorization" => "Bearer user-tok" }
+      expect(response.status).to eq(503)
     end
 
     it "does not call the rate limiter for the service caller" do

--- a/spec/requests/submission_authentication_spec.rb
+++ b/spec/requests/submission_authentication_spec.rb
@@ -80,6 +80,12 @@ RSpec.describe "Submission authentication", type: :request do
                            env: { "REMOTE_ADDR" => "203.0.113.9" }
     end
 
+    it "groups an anonymous IPv6 caller by /64" do
+      expect(@limiter).to receive(:allow?).with("ip:2001:db8:abcd:1234::/64", anything).and_return(true)
+      post "/submissions", params: attributes_for(:valid_submission),
+                           env: { "REMOTE_ADDR" => "2001:db8:abcd:1234:ffff::1" }
+    end
+
     it "rate-limits a logged-in caller by user id" do
       expect(@limiter).to receive(:allow?).with("u:user-1", anything).and_return(true)
       post "/submissions", params: attributes_for(:valid_submission),
@@ -101,8 +107,8 @@ RSpec.describe "Submission authentication", type: :request do
 
   describe "read rate limit" do
     it "429s a read over the per-minute limit" do
-      allow(@limiter).to receive(:allow?).and_return(false)
-      get "/submissions/anytoken"
+      expect(@limiter).to receive(:allow?).with("r:203.0.113.9", anything).and_return(false)
+      get "/submissions/anytoken", env: { "REMOTE_ADDR" => "203.0.113.9" }
       expect(response.status).to eq(429)
     end
 

--- a/spec/services/caching_token_validator_spec.rb
+++ b/spec/services/caching_token_validator_spec.rb
@@ -63,4 +63,15 @@ RSpec.describe CachingTokenValidator do
     cv.validate("b")
     expect(inner.calls).to eq(3)
   end
+
+  it "purges an expired entry to admit a new one at capacity" do
+    inner = CountingValidator.new("u1")
+    t = 1_000_000
+    cv = described_class.new(inner, ttl_seconds: 60, negative_ttl_seconds: 5, max_entries: 1, clock: -> { t })
+    cv.validate("a")
+    t += 120
+    cv.validate("b")
+    cv.validate("b")
+    expect(inner.calls).to eq(2)
+  end
 end

--- a/spec/services/caching_token_validator_spec.rb
+++ b/spec/services/caching_token_validator_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.describe CachingTokenValidator do
+  # Counts inner calls so we can assert caching behaviour.
+  class CountingValidator
+    attr_reader :calls
+
+    def initialize(result)
+      @result = result
+      @calls = 0
+    end
+
+    def validate(_token)
+      @calls += 1
+      @result.is_a?(Exception) ? (raise @result) : @result
+    end
+  end
+
+  it "caches a positive result" do
+    inner = CountingValidator.new("u1")
+    cv = described_class.new(inner, ttl_seconds: 60, negative_ttl_seconds: 5, max_entries: 1000)
+    3.times { expect(cv.validate("t")).to eq("u1") }
+    expect(inner.calls).to eq(1)
+  end
+
+  it "caches an :invalid result" do
+    inner = CountingValidator.new(:invalid)
+    cv = described_class.new(inner, ttl_seconds: 60, negative_ttl_seconds: 5, max_entries: 1000)
+    3.times { expect(cv.validate("t")).to eq(:invalid) }
+    expect(inner.calls).to eq(1)
+  end
+
+  it "does not cache transient errors" do
+    inner = CountingValidator.new(NewtonTokenValidator::TransientError.new("down"))
+    cv = described_class.new(inner, ttl_seconds: 60, negative_ttl_seconds: 5, max_entries: 1000)
+    2.times { expect { cv.validate("t") }.to raise_error(NewtonTokenValidator::TransientError) }
+    expect(inner.calls).to eq(2)
+  end
+
+  it "re-validates after ttl expiry" do
+    inner = CountingValidator.new("u1")
+    t = 1_000_000
+    cv = described_class.new(inner, ttl_seconds: 60, negative_ttl_seconds: 5, max_entries: 1000, clock: -> { t })
+    cv.validate("t")
+    t += 120
+    cv.validate("t")
+    expect(inner.calls).to eq(2)
+  end
+
+  it "keys the cache per token" do
+    inner = CountingValidator.new("u1")
+    cv = described_class.new(inner, ttl_seconds: 60, negative_ttl_seconds: 5, max_entries: 1000)
+    cv.validate("a")
+    cv.validate("b")
+    expect(inner.calls).to eq(2)
+  end
+
+  it "bounds the number of cached entries" do
+    inner = CountingValidator.new("u1")
+    cv = described_class.new(inner, ttl_seconds: 60, negative_ttl_seconds: 5, max_entries: 1)
+    cv.validate("a")
+    cv.validate("b")
+    cv.validate("b")
+    expect(inner.calls).to eq(3)
+  end
+end

--- a/spec/services/newton_token_validator_spec.rb
+++ b/spec/services/newton_token_validator_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe NewtonTokenValidator do
+  # Inject a fake HTTP responder so we test our status/body mapping, not the network.
+  def validator_returning(status, body = "")
+    resp = Struct.new(:code, :body).new(status.to_s, body)
+    fake = double("http")
+    allow(fake).to receive(:request).and_return(resp)
+    allow(Net::HTTP).to receive(:start).and_yield(fake).and_return(resp)
+    described_class.new("http://newton.test/validate/")
+  end
+
+  it "returns the user id on 200 with a user_id" do
+    v = validator_returning(200, '{"user_id":"u42"}')
+    expect(v.validate("good")).to eq("u42")
+  end
+
+  it "returns :invalid on 401" do
+    v = validator_returning(401)
+    expect(v.validate("bad")).to eq(:invalid)
+  end
+
+  it "returns :invalid on 403" do
+    v = validator_returning(403)
+    expect(v.validate("bad")).to eq(:invalid)
+  end
+
+  it "raises TransientError on 500" do
+    v = validator_returning(500)
+    expect { v.validate("x") }.to raise_error(NewtonTokenValidator::TransientError)
+  end
+
+  it "raises TransientError on 200 with an empty user_id (fail closed)" do
+    v = validator_returning(200, '{"user_id":""}')
+    expect { v.validate("x") }.to raise_error(NewtonTokenValidator::TransientError)
+  end
+
+  it "raises TransientError on unparseable body" do
+    v = validator_returning(200, 'not-json')
+    expect { v.validate("x") }.to raise_error(NewtonTokenValidator::TransientError)
+  end
+end

--- a/spec/services/submission_rate_limiter_spec.rb
+++ b/spec/services/submission_rate_limiter_spec.rb
@@ -64,4 +64,18 @@ RSpec.describe SubmissionRateLimiter do
     results = 5.times.map { limiter.allow?("k", 3) }
     expect(results).to eq([true, true, true, false, false])
   end
+
+  it "charges the given amount via incrby and blocks once the budget is exceeded" do
+    counts = Hash.new(0)
+    allow(redis).to receive(:incrby) { |key, amount| counts[key] += amount }
+    limiter = described_class.new(host: "localhost", port: 6379, password: nil, clock: -> { 0 })
+    expect(limiter.allow?("k", 10, 6)).to eq(true)   # 6 <= 10
+    expect(limiter.allow?("k", 10, 6)).to eq(false)  # 12 > 10
+  end
+
+  it "sets an expiry on the first amounted hit in a window" do
+    allow(redis).to receive(:incrby).and_return(6)
+    expect(redis).to receive(:expire).with(a_string_matching(/\Ajudge0:rl:k:\d+\z/), 70)
+    described_class.new(host: "localhost", port: 6379, password: nil).allow?("k", 10, 6)
+  end
 end

--- a/spec/services/submission_rate_limiter_spec.rb
+++ b/spec/services/submission_rate_limiter_spec.rb
@@ -10,39 +10,39 @@ RSpec.describe SubmissionRateLimiter do
 
   it "allows a key under its limit" do
     allow(redis).to receive(:incr).and_return(1)
-    limiter = described_class.new("redis://localhost:6379/0")
+    limiter = described_class.new(host: "localhost", port: 6379, password: nil)
     expect(limiter.allow?("k", 3)).to eq(true)
   end
 
   it "blocks a key over its limit" do
     allow(redis).to receive(:incr).and_return(4)
-    limiter = described_class.new("redis://localhost:6379/0")
+    limiter = described_class.new(host: "localhost", port: 6379, password: nil)
     expect(limiter.allow?("k", 3)).to eq(false)
   end
 
   it "sets an expiry only on the first hit in a window" do
     allow(redis).to receive(:incr).and_return(1)
     expect(redis).to receive(:expire).with(a_string_matching(/\Ajudge0:rl:k:\d+\z/), 70)
-    limiter = described_class.new("redis://localhost:6379/0")
+    limiter = described_class.new(host: "localhost", port: 6379, password: nil)
     limiter.allow?("k", 3)
   end
 
   it "does not set an expiry on a later hit in the same window" do
     allow(redis).to receive(:incr).and_return(2)
     expect(redis).not_to receive(:expire)
-    limiter = described_class.new("redis://localhost:6379/0")
+    limiter = described_class.new(host: "localhost", port: 6379, password: nil)
     limiter.allow?("k", 3)
   end
 
-  it "constructs its redis client from the given url" do
-    expect(Redis).to receive(:new).with(url: "redis://example:6379/2").and_return(redis)
+  it "constructs its redis client from host, port, and password" do
+    expect(Redis).to receive(:new).with(host: "example", port: 6379, password: "secret").and_return(redis)
     allow(redis).to receive(:incr).and_return(1)
-    described_class.new("redis://example:6379/2").allow?("k", 3)
+    described_class.new(host: "example", port: 6379, password: "secret").allow?("k", 3)
   end
 
   it "uses the injectable clock to key the window" do
     allow(redis).to receive(:incr).with("judge0:rl:k:0").and_return(1)
-    limiter = described_class.new("redis://localhost:6379/0", clock: -> { 0 })
+    limiter = described_class.new(host: "localhost", port: 6379, password: nil, clock: -> { 0 })
     expect(limiter.allow?("k", 3)).to eq(true)
   end
 
@@ -50,7 +50,7 @@ RSpec.describe SubmissionRateLimiter do
     t = 0
     counts = Hash.new(0)
     allow(redis).to receive(:incr) { |key| counts[key] += 1 }
-    limiter = described_class.new("redis://localhost:6379/0", clock: -> { t })
+    limiter = described_class.new(host: "localhost", port: 6379, password: nil, clock: -> { t })
     expect(limiter.allow?("k", 1)).to eq(true)
     expect(limiter.allow?("k", 1)).to eq(false)
     t += 60
@@ -60,7 +60,7 @@ RSpec.describe SubmissionRateLimiter do
   it "enforces the given per-call limit across five calls" do
     counts = Hash.new(0)
     allow(redis).to receive(:incr) { |key| counts[key] += 1 }
-    limiter = described_class.new("redis://localhost:6379/0", clock: -> { 0 })
+    limiter = described_class.new(host: "localhost", port: 6379, password: nil, clock: -> { 0 })
     results = 5.times.map { limiter.allow?("k", 3) }
     expect(results).to eq([true, true, true, false, false])
   end

--- a/spec/services/submission_rate_limiter_spec.rb
+++ b/spec/services/submission_rate_limiter_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+RSpec.describe SubmissionRateLimiter do
+  let(:redis) { instance_double(Redis) }
+
+  before do
+    allow(Redis).to receive(:new).and_return(redis)
+    allow(redis).to receive(:expire)
+  end
+
+  it "allows a key under its limit" do
+    allow(redis).to receive(:incr).and_return(1)
+    limiter = described_class.new("redis://localhost:6379/0")
+    expect(limiter.allow?("k", 3)).to eq(true)
+  end
+
+  it "blocks a key over its limit" do
+    allow(redis).to receive(:incr).and_return(4)
+    limiter = described_class.new("redis://localhost:6379/0")
+    expect(limiter.allow?("k", 3)).to eq(false)
+  end
+
+  it "sets an expiry only on the first hit in a window" do
+    allow(redis).to receive(:incr).and_return(1)
+    expect(redis).to receive(:expire).with(a_string_matching(/\Ajudge0:rl:k:\d+\z/), 70)
+    limiter = described_class.new("redis://localhost:6379/0")
+    limiter.allow?("k", 3)
+  end
+
+  it "does not set an expiry on a later hit in the same window" do
+    allow(redis).to receive(:incr).and_return(2)
+    expect(redis).not_to receive(:expire)
+    limiter = described_class.new("redis://localhost:6379/0")
+    limiter.allow?("k", 3)
+  end
+
+  it "constructs its redis client from the given url" do
+    expect(Redis).to receive(:new).with(url: "redis://example:6379/2").and_return(redis)
+    allow(redis).to receive(:incr).and_return(1)
+    described_class.new("redis://example:6379/2").allow?("k", 3)
+  end
+
+  it "uses the injectable clock to key the window" do
+    allow(redis).to receive(:incr).with("judge0:rl:k:0").and_return(1)
+    limiter = described_class.new("redis://localhost:6379/0", clock: -> { 0 })
+    expect(limiter.allow?("k", 3)).to eq(true)
+  end
+
+  it "resets the count at the next window boundary" do
+    t = 0
+    counts = Hash.new(0)
+    allow(redis).to receive(:incr) { |key| counts[key] += 1 }
+    limiter = described_class.new("redis://localhost:6379/0", clock: -> { t })
+    expect(limiter.allow?("k", 1)).to eq(true)
+    expect(limiter.allow?("k", 1)).to eq(false)
+    t += 60
+    expect(limiter.allow?("k", 1)).to eq(true)
+  end
+
+  it "enforces the given per-call limit across five calls" do
+    counts = Hash.new(0)
+    allow(redis).to receive(:incr) { |key| counts[key] += 1 }
+    limiter = described_class.new("redis://localhost:6379/0", clock: -> { 0 })
+    results = 5.times.map { limiter.allow?("k", 3) }
+    expect(results).to eq([true, true, true, false, false])
+  end
+end


### PR DESCRIPTION
> Stacked on #39 (base = `security/ns-13252-judge0-submission-auth`), which carries the code only. **Merge #39 first, then this.**

Adds the specs so #39 reviews as a clean code-only diff. Ticket: **NS-13252**.

## Specs
- `spec/services/newton_token_validator_spec.rb` — status mapping + transient/fail-closed.
- `spec/services/caching_token_validator_spec.rb` — positive/negative/transient caching, TTL expiry, per-token keying, size bound (reject-new at capacity), and lazy eviction ("purges an expired entry to admit a new one at capacity"). (Cache is digest-keyed internally; specs drive the public API.)
- `spec/services/submission_rate_limiter_spec.rb` — per-call `allow?(key, limit)` against the `host:`/`port:`/`password:` constructor; bound example (limit 3 → true,true,true,false,false); **plus the `amount`/`incrby` batch path (charges N units, blocks once the budget is exceeded, sets expiry on the first amounted hit)**.
- `spec/requests/submission_authentication_spec.rb` —
  - **auth branch:** anonymous request without a bearer is not 401'd; invalid bearer → 403; transient validator → 503 (fail closed); service token allowed; valid user bearer allowed.
  - **rate limit:** user over limit → 429; service bypass (limiter not even called); limiter raise → 503 (fail closed); anonymous keyed `ip:<client_ip>`; **client IP = last `X-Forwarded-For` entry**; **IPv6 grouped `/64`**; logged-in keyed `u:<user_id>`; anonymous over limit → 429; **`batch_create` charges the batch size**; **a cache-miss validation is IP-throttled (`auth:<ip>`) and fails closed over the limit**.
  - **read rate limit:** read over limit → 429; **signed-in read keyed `r:u:<user_id>`**; limiter raise → 503; service read bypass.
- `spec/controllers/submissions_controller_spec.rb` — existing controller spec patched to authenticate as the service caller.

## Request flow under test (matches #39)

```text
POST /submissions              (create / batch_create)
  |
  v  authenticate_submission_request
  |  read  Authorization: Bearer <token>
  |     |- no token .............. ANON     key ip:<client_ip>   (120/min)
  |     |- == service secret ..... SERVICE  (bypasses rate limit)
  |     `- else -> (cache miss? throttle auth:<ip>) validate @ newton-api  GET /api/v1/user/auth/validate/
  |                |- 401/403 .....> 403 "Invalid token"
  |                |- transient ...> 503  (fail closed)
  |                `- 200 ......... USER    key u:<user_id>      (60/min)
  |
  v  enforce_submission_rate_limit  (Redis fixed-window/min; charges batch size; global; fails closed (503))
        |- SERVICE ......... bypass
        |- over limit .....> 429 "Rate limit exceeded"
        `- under limit -> create submission


GET /submissions/{token}       (show / batch_show)
  |
  v  enforce_read_rate_limit    (300/min; fails closed (503))
        |- SERVICE ......... bypass       (grading fetches results via show)
        |- USER ............ key r:u:<user_id>
        |- ANON ............ key r:<client_ip>
        |- over limit .....> 429
        `- under limit ---> 200 | 404 if token unknown
```

**Client IP** = last (rightmost) non-empty `X-Forwarded-For` entry, `remote_ip` fallback; IPv4-mapped IPv6 normalized to real IPv4; IPv6 grouped by `/64`. **Tiers** — service: bypass · logged-in `u:<user_id>` 60/min · anonymous `ip:<client_ip>` 120/min · read `r:u:<user_id>` / `r:<client_ip>` 300/min. Auth and rate-limiting both **fail closed**.

Judge0 has no local RSpec/CI toolchain — files are `ruby -c`-clean and the validator/limiter logic was verified against the live newton-api + real Redis; **run `rspec` in the Docker dev stack / CI before merge**.
